### PR TITLE
Fixed issue #175 and #174.

### DIFF
--- a/src/main/java/spoilagesystem/Commands/ReloadCommand.java
+++ b/src/main/java/spoilagesystem/Commands/ReloadCommand.java
@@ -4,6 +4,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import spoilagesystem.ConfigManager;
+import spoilagesystem.FoodSpoilage;
 
 public class ReloadCommand {
 
@@ -11,7 +12,8 @@ public class ReloadCommand {
         if (sender instanceof Player) {
             Player player = (Player) sender;
             if (player.hasPermission("fs.reload") || player.hasPermission("fs.admin")) {
-                ConfigManager.getInstance().reloadValuesFromConfig();
+                // ConfigManager.getInstance().reloadValuesFromConfig();
+                ConfigManager.getInstance().reload();
                 player.sendMessage(ChatColor.GREEN + ConfigManager.getInstance().valuesLoadedText);
             }
             else {
@@ -19,7 +21,8 @@ public class ReloadCommand {
             }
         }
         else {
-            ConfigManager.getInstance().reloadValuesFromConfig();
+            // ConfigManager.getInstance().reloadValuesFromConfig();
+            ConfigManager.getInstance().reload();
             System.out.println(ConfigManager.getInstance().valuesLoadedText);
         }
     }

--- a/src/main/java/spoilagesystem/Commands/TimeLeftCommand.java
+++ b/src/main/java/spoilagesystem/Commands/TimeLeftCommand.java
@@ -21,7 +21,7 @@ public class TimeLeftCommand {
 
         if (timeLeft == null) {
             // this item will never spoil
-            player.sendMessage(ConfigManager.getInstance().thisItemWillNeverSpoilText);
+            player.sendMessage(ConfigManager.getInstance().neverSpoilText);
             return;
         }
 

--- a/src/main/java/spoilagesystem/ConfigManager.java
+++ b/src/main/java/spoilagesystem/ConfigManager.java
@@ -1,6 +1,8 @@
 package spoilagesystem;
 
 import org.bukkit.Material;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.inventory.ItemStack;
 
 import java.io.File;
 import java.util.HashMap;
@@ -14,96 +16,195 @@ public class ConfigManager {
     private static ConfigManager instance;
 
     private ConfigManager() {
-
+        reloaded = 0;
+        this.random = new Random(System.currentTimeMillis()); // Time as seed.
     }
 
     public static ConfigManager getInstance() {
-        if (instance == null) {
-            instance = new ConfigManager();
-        }
-        return instance;
+        return instance == null ? instance = new ConfigManager() : instance;
     }
 
     private static final Map<Material, Float> SPOIL_CHANCE = new HashMap<Material, Float>() {{
         put(WHEAT, 0.3f);
     }};
 
-    private static final Map<Material, Integer> SPOIL_TIMES = new HashMap<Material, Integer>() {{
-        put(BREAD, 24);
-        put(POTATO, 48);
-        put(CARROT, 48);
-        put(BEETROOT, 48);
-        put(BEEF, 24);
-        put(PORKCHOP, 24);
-        put(CHICKEN, 24);
-        put(COD, 24);
-        put(SALMON, 24);
-        put(MUTTON, 24);
-        put(RABBIT, 24);
-        put(TROPICAL_FISH, 24);
-        put(PUFFERFISH, 24);
-        put(MUSHROOM_STEW, 72);
-        put(RABBIT_STEW, 96);
-        put(BEETROOT_SOUP, 72);
-        put(COOKED_BEEF, 72);
-        put(COOKED_PORKCHOP, 72);
-        put(COOKED_CHICKEN, 72);
-        put(COOKED_SALMON, 72);
-        put(COOKED_MUTTON, 72);
-        put(COOKED_RABBIT, 72);
-        put(COOKED_COD, 72);
-        put(WHEAT, 48);
-        put(HAY_BLOCK, 48);
-        put(MELON, 48);
-        put(PUMPKIN, 48);
-        put(BROWN_MUSHROOM, 48);
-        put(RED_MUSHROOM, 48);
-        put(NETHER_WART, 168);
-        put(MELON_SLICE, 24);
-        put(CAKE, 24);
-        put(PUMPKIN_PIE, 24);
-        put(SUGAR, 72);
-        put(EGG, 72);
-        put(SUGAR_CANE, 48);
-        put(APPLE, 48);
-        put(COOKIE, 94);
-        put(POISONOUS_POTATO, 24);
-        put(CHORUS_FRUIT, 94);
-        put(DRIED_KELP, 72);
-        put(BAKED_POTATO, 94);
-        put(SWEET_BERRIES, 48);
+    private static final Map<String, Integer> DEFAULT_SPOIL_TIMES = new HashMap<String, Integer>() {{
+        put("BREAD", 24);
+        put("POTATO", 48);
+        put("CARROT", 48);
+        put("BEETROOT", 48);
+        put("BEEF", 24);
+        put("PORKCHOP", 24);
+        put("CHICKEN", 24);
+        put("COD", 24);
+        put("SALMON", 24);
+        put("MUTTON", 24);
+        put("RABBIT", 24);
+        put("TROPICAL_FISH", 24);
+        put("PUFFERFISH", 24);
+        put("MUSHROOM_STEW", 72);
+        put("RABBIT_STEW", 96);
+        put("BEETROOT_SOUP", 72);
+        put("COOKED_BEEF", 72);
+        put("COOKED_PORKCHOP", 72);
+        put("COOKED_CHICKEN", 72);
+        put("COOKED_SALMON", 72);
+        put("COOKED_MUTTON", 72);
+        put("COOKED_RABBIT", 72);
+        put("COOKED_COD", 72);
+        put("WHEAT", 48);
+        put("HAY_BLOCK", 48);
+        put("MELON", 48);
+        put("PUMPKIN", 48);
+        put("BROWN_MUSHROOM", 48);
+        put("RED_MUSHROOM", 48);
+        put("NETHER_WART", 168);
+        put("MELON_SLICE", 24);
+        put("CAKE", 24);
+        put("PUMPKIN_PIE", 24);
+        put("SUGAR", 72);
+        put("EGG", 72);
+        put("SUGAR_CANE", 48);
+        put("APPLE", 48);
+        put("COOKIE", 94);
+        put("POISONOUS_POTATO", 24);
+        put("CHORUS_FRUIT", 94);
+        put("DRIED_KELP", 72);
+        put("BAKED_POTATO", 94);
+        put("SWEET_BERRIES", 48);
     }};
+
+    /**
+     * Use this to see the spoil-time caching in real-time (for testing purposes only).
+     */
+    private static final boolean debug = false;
+    private final Random random;
+    private static long reloaded;
+    private static long last_cached = 0;
+    private static final HashMap<Material, Integer> cache = new HashMap<>();
 
     public String expiryDateText = "Expiry Date:";
     public String valuesLoadedText = "Values Loaded!";
     public String noPermsText = "Sorry! In order to use this command, you need the following permission: 'fs.reload'";
     public String spoiledFoodName = "Spoiled Food";
     public String spoiledFoodLore = "This food has gone bad.";
-    public String thisItemWillNeverSpoilText = "This item will never spoil.";
+    public String neverSpoilText = "This item will never spoil.";
     public String timeLeftText = "This will expire in %s.";
     public String lessThanAnHour = "This will expire in less than an hour.";
 
+    /**
+     * Method to obtain the Spoilage Time for the given Material.
+     * <p>
+     *     Due to the nature of how you have currently used this method, returning {@code 0} seems to a valid 'error'
+     *     response from this method, this method uses {@link #cache}, {@link #last_cached} and {@link #reloaded} to
+     *     create optimal lookup times for each Material type.
+     *
+     *     <br><br>API - Call #1
+     *      <br>[00:11:16 INFO]: Getting the spoil-time for COOKED_BEEF
+     *      <br>[00:11:16 INFO]: First-Time collecting information, initialising Cache.
+     *      <br>[00:11:16 INFO]: Either Cache was restarted or Type had not been cached yet.
+     *      <br>[00:11:16 INFO]: Time from configuration for COOKED_BEEF:       72
+     *      <br>[00:11:16 INFO]: As time isn't 0, caching for the next time.
+     *
+     *      <br><br>API - Call #2+
+     *      <br>[00:11:26 INFO]: Getting the spoil-time for COOKED_BEEF
+     *      <br>[00:11:26 INFO]: Cache is still valid, returning spoil-time from map.
+     *
+     *      <br><br>API - Call after Reload
+     *      <br>[00:11:46 INFO]: Getting the spoil-time for COOKED_BEEF
+     *      <br>[00:11:46 INFO]: Reload has occurred since last collection, clearing and restarting Cache.
+     *      <br>[00:11:46 INFO]: Either Cache was restarted or Type had not been cached yet.
+     *      <br>[00:11:46 INFO]: Time from configuration for COOKED_BEEF:       72
+     *      <br>[00:11:46 INFO]: As time isn't 0, caching for the next time.<br>
+     *
+     * </p>
+     *
+     * @param type to obtain the spoilage time for.
+     * @return int time.
+     * @see org.bukkit.configuration.MemorySection#getInt(String)
+     */
     public int getTime(Material type) {
-        Integer time = SPOIL_TIMES.get(type);
-        return time != null ? time : 0;
-    }
-
-    public int getSpoilChance(Material type, int Qty) {
-        Float chance = SPOIL_CHANCE.get(type);
-        if (type != null) {
-            if (chance != null) {
-                Random rand = new Random();
-                float roll = rand.nextFloat();
-                if (roll <= chance) {
-                    return (int)(roll * Qty);
+        if (debug) {
+            System.out.println("Getting the spoil-time for " + type.name());
+        }
+        if (last_cached <= reloaded) { // Cover the initial boot, they will both be 0 when the first launch occurs.
+            if (debug) {
+                if (last_cached == reloaded && last_cached == 0) {
+                    System.out.println("First-Time collecting information, initialising Cache.");
+                } else {
+                    System.out.println("Reload has occurred since last collection, clearing and restarting Cache.");
                 }
             }
+            last_cached = System.currentTimeMillis(); // Override the 'last_cached' value to right now.
+            cache.clear(); // Clear the Cache if they reload.
+        } else { // if the cache is still valid.
+            if (debug) {
+                System.out.println("Cache is still valid, returning spoil-time from map.");
+            }
+            if (cache.containsKey(type)) { // If we've already cached the key, then return the value.
+                return cache.get(type); // Cache with working reload mechanisms!
+            }
         }
-        return 0;
+        if (debug) {
+            System.out.println("Either Cache was restarted or Type had not been cached yet.");
+        }
+        final int time = FoodSpoilage.getInstance().getConfig().getInt(type.name()); // Get the time from the config.
+        if (debug) {
+            System.out.println("Time from configuration for " + type.name() + ":\t" + time);
+        }
+        if (time != 0) { // If it isn't 0, then its valid, then we wanna cache it until the next reload.
+            if (debug) {
+                System.out.println("As time isn't 0, caching for the next time.");
+            }
+            cache.put(type, time);
+        }
+        return time; // Return the key.
     }
 
+    /**
+     * Method to obtain the spoil-chance for the given material->int parameters.
+     *
+     * @param type of the item.
+     * @param Qty or quantity of the item.
+     * @return spoil chance.
+     */
+    public int getSpoilChance(Material type, int Qty) {
+        final float chance = SPOIL_CHANCE.getOrDefault(type, 0f);
+        if (type == null || chance <= 0) return 0;
+        final float roll = random.nextFloat();
+        return roll <= chance ? (int) (roll * Qty) : 0;
+    }
+
+    /**
+     * Method to obtain the spoil-chance for the given Item.
+     *
+     * @param stack to reference
+     * @return spoil chance.
+     * @see #getSpoilChance(Material, int)
+     */
+    public int getSpoilChance(ItemStack stack) {
+        return getSpoilChance(stack.getType(), stack.getAmount());
+    }
+
+    /**
+     * Method to obtain <em>all</em> spoil times.
+     * <p>
+     *      Passing reference to the cache could be unsafe, so only returning a copy is easier.
+     *      <br>Plus, as we're looping through all the Material values, all values will be cached.
+     *      <br>Technically, to reduce lag (minuscule due to the new caching mechanism), this could
+     *      be called either on a task or at configuration reload to load all of the values into the cache,
+     *      but this is not required at all.
+     * </p>
+     *
+     * @return Spoil Times map->(material:int).
+     */
     public Map<Material, Integer> getSpoilTimes() {
-        return SPOIL_TIMES;
+        final HashMap<Material, Integer> spoilTimes = new HashMap<>();
+        for (Material value : values()) { // Loop through all the materials.
+            int time = getTime(value); // get the time.
+            if (time != 0) spoilTimes.put(value, time); // if it isn't 0, add it
+        }
+        return spoilTimes; // Return output.
     }
 
     public void ensureSmoothTransitionBetweenVersions() {
@@ -116,8 +217,25 @@ public class ConfigManager {
             LegacyStorageManager.getInstance().legacyLoadValuesFromConfig();
             LegacyStorageManager.getInstance().legacyLoadCustomText();
 
-            // save config
-            saveConfigDefaults();
+            // Pull old data to the new configuration without passing reference
+            // to the (this class) spoil-times map.
+            LegacyStorageManager.getInstance().spoilTimes.forEach((k, v) -> {
+                FoodSpoilage.getInstance().getConfig().addDefault(k.name(), v);
+            });
+
+            // save newer config
+            FoodSpoilage.getInstance().getConfig().addDefault("version", FoodSpoilage.getInstance().getVersion());
+            FoodSpoilage.getInstance().getConfig().addDefault("expiryDateText", expiryDateText);
+            FoodSpoilage.getInstance().getConfig().addDefault("valuesLoadedText", valuesLoadedText);
+            FoodSpoilage.getInstance().getConfig().addDefault("noPermsText", noPermsText);
+            FoodSpoilage.getInstance().getConfig().addDefault("spoiledFoodName", spoiledFoodName);
+            FoodSpoilage.getInstance().getConfig().addDefault("spoiledFoodLore", spoiledFoodLore);
+            FoodSpoilage.getInstance().getConfig().addDefault("thisItemWillNeverSpoilText", neverSpoilText);
+            FoodSpoilage.getInstance().getConfig().addDefault("timeLeftText", timeLeftText);
+            FoodSpoilage.getInstance().getConfig().addDefault("lessThanAnHour", lessThanAnHour);
+
+            FoodSpoilage.getInstance().getConfig().options().copyDefaults(true);
+            FoodSpoilage.getInstance().saveConfig();
 
             // delete old directory
             LegacyStorageManager.getInstance().deleteLegacyFiles(saveFolder);
@@ -126,169 +244,56 @@ public class ConfigManager {
 
     public void handleVersionMismatch() {
         // set version
-        if (!FoodSpoilage.getInstance().getConfig().isString("version")) {
-            FoodSpoilage.getInstance().getConfig().addDefault("version", FoodSpoilage.getInstance().getVersion());
-        }
-        else {
-            FoodSpoilage.getInstance().getConfig().set("version", FoodSpoilage.getInstance().getVersion());
+        final FoodSpoilage foodSpoilage = FoodSpoilage.getInstance();
+        final FileConfiguration config = foodSpoilage.getConfig();
+        if (!config.isString("version")) {
+            config.addDefault("version", foodSpoilage.getVersion());
+        } else {
+            config.set("version", foodSpoilage.getVersion());
+            foodSpoilage.saveConfig(); // Save the config after you update the version value.
         }
 
         // add defaults if they don't exist
-        SPOIL_TIMES.forEach((key, value) -> {
-            if (!FoodSpoilage.getInstance().getConfig().isInt(key.toString())) {
-                FoodSpoilage.getInstance().getConfig().addDefault(key.toString(), value);
+        DEFAULT_SPOIL_TIMES.forEach((key, value) -> {
+            if (!config.isInt(key)) {
+                config.addDefault(key, value);
             }
         });
 
-        if (!FoodSpoilage.getInstance().getConfig().isString("expiryDateText")) {
-            FoodSpoilage.getInstance().getConfig().addDefault("expiryDateText", expiryDateText);
-        }
-        if (!FoodSpoilage.getInstance().getConfig().isString("valuesLoadedText")) {
-            FoodSpoilage.getInstance().getConfig().addDefault("valuesLoadedText", valuesLoadedText);
-        }
-        if (!FoodSpoilage.getInstance().getConfig().isString("noPermsText")) {
-            FoodSpoilage.getInstance().getConfig().addDefault("noPermsText", noPermsText);
-        }
-        if (!FoodSpoilage.getInstance().getConfig().isString("spoiledFoodName")) {
-            FoodSpoilage.getInstance().getConfig().addDefault("spoiledFoodName", spoiledFoodName);
-        }
-        if (!FoodSpoilage.getInstance().getConfig().isString("spoiledFoodLore")) {
-            FoodSpoilage.getInstance().getConfig().addDefault("spoiledFoodLore", spoiledFoodLore);
-        }
-        if (!FoodSpoilage.getInstance().getConfig().isString("thisItemWillNeverSpoilText")) {
-            FoodSpoilage.getInstance().getConfig().addDefault("thisItemWillNeverSpoilText", thisItemWillNeverSpoilText);
-        }
-        if (!FoodSpoilage.getInstance().getConfig().isString("timeLeftText")) {
-            FoodSpoilage.getInstance().getConfig().addDefault("timeLeftText", timeLeftText);
-        }
-        if (!FoodSpoilage.getInstance().getConfig().isString("lessThanAnHour")) {
-            FoodSpoilage.getInstance().getConfig().addDefault("lessThanAnHour", lessThanAnHour);
-        }
+        if (!config.isString("expiryDateText")) config.addDefault("expiryDateText", expiryDateText);
+        if (!config.isString("valuesLoadedText")) config.addDefault("valuesLoadedText", valuesLoadedText);
+        if (!config.isString("noPermsText")) config.addDefault("noPermsText", noPermsText);
+        if (!config.isString("spoiledFoodName")) config.addDefault("spoiledFoodName", spoiledFoodName);
+        if (!config.isString("spoiledFoodLore")) config.addDefault("spoiledFoodLore", spoiledFoodLore);
+        if (!config.isString("thisItemWillNeverSpoilText")) config.addDefault("thisItemWillNeverSpoilText", neverSpoilText);
+        if (!config.isString("timeLeftText")) config.addDefault("timeLeftText", timeLeftText);
+        if (!config.isString("lessThanAnHour")) config.addDefault("lessThanAnHour", lessThanAnHour);
     }
 
-    public void saveConfigDefaults() {
-        FoodSpoilage.getInstance().getConfig().addDefault("version", FoodSpoilage.getInstance().getVersion());
+    public void reload() {
+        reloaded = System.currentTimeMillis();
+        FoodSpoilage.getInstance().reloadConfig();
+        final FileConfiguration config = FoodSpoilage.getInstance().getConfig();
+        expiryDateText = config.getString("expiryDateText");
+        valuesLoadedText = config.getString("valuesLoadedText");
+        noPermsText = config.getString("noPermsText");
+        spoiledFoodName = config.getString("spoiledFoodName");
+        spoiledFoodLore = config.getString("spoiledFoodLore");
+        timeLeftText = config.getString("timeLeftText");
+        lessThanAnHour = config.getString("lessThanAnHour");
+    }
 
-        SPOIL_TIMES.forEach((key, value) -> FoodSpoilage.getInstance().getConfig().addDefault(key.toString(), value));
-
-        FoodSpoilage.getInstance().getConfig().addDefault("expiryDateText", expiryDateText);
-        FoodSpoilage.getInstance().getConfig().addDefault("valuesLoadedText", valuesLoadedText);
-        FoodSpoilage.getInstance().getConfig().addDefault("noPermsText", noPermsText);
-        FoodSpoilage.getInstance().getConfig().addDefault("spoiledFoodName", spoiledFoodName);
-        FoodSpoilage.getInstance().getConfig().addDefault("spoiledFoodLore", spoiledFoodLore);
-        FoodSpoilage.getInstance().getConfig().addDefault("thisItemWillNeverSpoilText", thisItemWillNeverSpoilText);
-        FoodSpoilage.getInstance().getConfig().addDefault("timeLeftText", timeLeftText);
-        FoodSpoilage.getInstance().getConfig().addDefault("lessThanAnHour", lessThanAnHour);
-
-        FoodSpoilage.getInstance().getConfig().options().copyDefaults(true);
+    public void create() {
+        final FileConfiguration config = FoodSpoilage.getInstance().getConfig();
+        config.set("version", FoodSpoilage.getInstance().getVersion());
+        DEFAULT_SPOIL_TIMES.forEach(config::set);
+        config.set("expiryDateText", expiryDateText);
+        config.set("valuesLoadedText", valuesLoadedText);
+        config.set("noPermsText", noPermsText);
+        config.set("spoiledFoodName", spoiledFoodName);
+        config.set("spoiledFoodLore", spoiledFoodLore);
+        config.set("timeLeftText", timeLeftText);
+        config.set("lessThanAnHour", lessThanAnHour);
         FoodSpoilage.getInstance().saveConfig();
-    }
-
-    public void loadValuesFromConfig() {
-        SPOIL_TIMES.put(BREAD, FoodSpoilage.getInstance().getConfig().getInt("BREAD"));
-        SPOIL_TIMES.put(POTATO, FoodSpoilage.getInstance().getConfig().getInt("POTATO"));
-        SPOIL_TIMES.put(CARROT, FoodSpoilage.getInstance().getConfig().getInt("CARROT"));
-        SPOIL_TIMES.put(BEETROOT, FoodSpoilage.getInstance().getConfig().getInt("BEETROOT"));
-        SPOIL_TIMES.put(BEEF, FoodSpoilage.getInstance().getConfig().getInt("BEEF"));
-        SPOIL_TIMES.put(PORKCHOP, FoodSpoilage.getInstance().getConfig().getInt("PORKCHOP"));
-        SPOIL_TIMES.put(CHICKEN, FoodSpoilage.getInstance().getConfig().getInt("CHICKEN"));
-        SPOIL_TIMES.put(COD, FoodSpoilage.getInstance().getConfig().getInt("COD"));
-        SPOIL_TIMES.put(SALMON, FoodSpoilage.getInstance().getConfig().getInt("SALMON"));
-        SPOIL_TIMES.put(MUTTON, FoodSpoilage.getInstance().getConfig().getInt("MUTTON"));
-        SPOIL_TIMES.put(RABBIT, FoodSpoilage.getInstance().getConfig().getInt("RABBIT"));
-        SPOIL_TIMES.put(TROPICAL_FISH, FoodSpoilage.getInstance().getConfig().getInt("TROPICAL_FISH"));
-        SPOIL_TIMES.put(PUFFERFISH, FoodSpoilage.getInstance().getConfig().getInt("PUFFERFISH"));
-        SPOIL_TIMES.put(MUSHROOM_STEW, FoodSpoilage.getInstance().getConfig().getInt("MUSHROOM_STEW"));
-        SPOIL_TIMES.put(RABBIT_STEW, FoodSpoilage.getInstance().getConfig().getInt("RABBIT_STEW"));
-        SPOIL_TIMES.put(BEETROOT_SOUP, FoodSpoilage.getInstance().getConfig().getInt("BEETROOT_SOUP"));
-        SPOIL_TIMES.put(COOKED_BEEF, FoodSpoilage.getInstance().getConfig().getInt("COOKED_BEEF"));
-        SPOIL_TIMES.put(COOKED_PORKCHOP, FoodSpoilage.getInstance().getConfig().getInt("COOKED_PORKCHOP"));
-        SPOIL_TIMES.put(COOKED_CHICKEN, FoodSpoilage.getInstance().getConfig().getInt("COOKED_CHICKEN"));
-        SPOIL_TIMES.put(COOKED_SALMON, FoodSpoilage.getInstance().getConfig().getInt("COOKED_SALMON"));
-        SPOIL_TIMES.put(COOKED_MUTTON, FoodSpoilage.getInstance().getConfig().getInt("COOKED_MUTTON"));
-        SPOIL_TIMES.put(COOKED_RABBIT, FoodSpoilage.getInstance().getConfig().getInt("COOKED_RABBIT"));
-        SPOIL_TIMES.put(COOKED_COD, FoodSpoilage.getInstance().getConfig().getInt("COOKED_COD"));
-        SPOIL_TIMES.put(WHEAT, FoodSpoilage.getInstance().getConfig().getInt("WHEAT"));
-        SPOIL_TIMES.put(MELON, FoodSpoilage.getInstance().getConfig().getInt("MELON"));
-        SPOIL_TIMES.put(PUMPKIN, FoodSpoilage.getInstance().getConfig().getInt("PUMPKIN"));
-        SPOIL_TIMES.put(BROWN_MUSHROOM, FoodSpoilage.getInstance().getConfig().getInt("BROWN_MUSHROOM"));
-        SPOIL_TIMES.put(RED_MUSHROOM, FoodSpoilage.getInstance().getConfig().getInt("RED_MUSHROOM"));
-        SPOIL_TIMES.put(NETHER_WART, FoodSpoilage.getInstance().getConfig().getInt("NETHER_WART"));
-        SPOIL_TIMES.put(MELON_SLICE, FoodSpoilage.getInstance().getConfig().getInt("MELON_SLICE"));
-        SPOIL_TIMES.put(CAKE, FoodSpoilage.getInstance().getConfig().getInt("CAKE"));
-        SPOIL_TIMES.put(PUMPKIN_PIE, FoodSpoilage.getInstance().getConfig().getInt("PUMPKIN_PIE"));
-        SPOIL_TIMES.put(SUGAR, FoodSpoilage.getInstance().getConfig().getInt("SUGAR"));
-        SPOIL_TIMES.put(EGG, FoodSpoilage.getInstance().getConfig().getInt("EGG"));
-        SPOIL_TIMES.put(SUGAR_CANE, FoodSpoilage.getInstance().getConfig().getInt("SUGAR_CANE"));
-        SPOIL_TIMES.put(APPLE, FoodSpoilage.getInstance().getConfig().getInt("APPLE"));
-        SPOIL_TIMES.put(COOKIE, FoodSpoilage.getInstance().getConfig().getInt("COOKIE"));
-        SPOIL_TIMES.put(POISONOUS_POTATO, FoodSpoilage.getInstance().getConfig().getInt("POISONOUS_POTATO"));
-        SPOIL_TIMES.put(CHORUS_FRUIT, FoodSpoilage.getInstance().getConfig().getInt("CHORUS_FRUIT"));
-        SPOIL_TIMES.put(DRIED_KELP, FoodSpoilage.getInstance().getConfig().getInt("DRIED_KELP"));
-        SPOIL_TIMES.put(BAKED_POTATO, FoodSpoilage.getInstance().getConfig().getInt("BAKED_POTATO"));
-        SPOIL_TIMES.put(SWEET_BERRIES, FoodSpoilage.getInstance().getConfig().getInt("SWEET_BERRIES"));
-        SPOIL_TIMES.put(HAY_BLOCK, FoodSpoilage.getInstance().getConfig().getInt("HAY_BLOCK"));
-
-        expiryDateText = FoodSpoilage.getInstance().getConfig().getString("expiryDateText");
-        valuesLoadedText = FoodSpoilage.getInstance().getConfig().getString("valuesLoadedText");
-        noPermsText = FoodSpoilage.getInstance().getConfig().getString("noPermsText");
-        spoiledFoodName = FoodSpoilage.getInstance().getConfig().getString("spoiledFoodName");
-        spoiledFoodLore = FoodSpoilage.getInstance().getConfig().getString("spoiledFoodLore");
-        timeLeftText = FoodSpoilage.getInstance().getConfig().getString("timeLeftText");
-        lessThanAnHour = FoodSpoilage.getInstance().getConfig().getString("lessThanAnHour");
-    }
-
-    public void reloadValuesFromConfig() {
-        SPOIL_TIMES.replace(BREAD, FoodSpoilage.getInstance().getConfig().getInt("BREAD"));
-        SPOIL_TIMES.replace(POTATO, FoodSpoilage.getInstance().getConfig().getInt("POTATO"));
-        SPOIL_TIMES.replace(CARROT, FoodSpoilage.getInstance().getConfig().getInt("CARROT"));
-        SPOIL_TIMES.replace(BEETROOT, FoodSpoilage.getInstance().getConfig().getInt("BEETROOT"));
-        SPOIL_TIMES.replace(BEEF, FoodSpoilage.getInstance().getConfig().getInt("BEEF"));
-        SPOIL_TIMES.replace(PORKCHOP, FoodSpoilage.getInstance().getConfig().getInt("PORKCHOP"));
-        SPOIL_TIMES.replace(CHICKEN, FoodSpoilage.getInstance().getConfig().getInt("CHICKEN"));
-        SPOIL_TIMES.replace(COD, FoodSpoilage.getInstance().getConfig().getInt("COD"));
-        SPOIL_TIMES.replace(SALMON, FoodSpoilage.getInstance().getConfig().getInt("SALMON"));
-        SPOIL_TIMES.replace(MUTTON, FoodSpoilage.getInstance().getConfig().getInt("MUTTON"));
-        SPOIL_TIMES.replace(RABBIT, FoodSpoilage.getInstance().getConfig().getInt("RABBIT"));
-        SPOIL_TIMES.replace(TROPICAL_FISH, FoodSpoilage.getInstance().getConfig().getInt("TROPICAL_FISH"));
-        SPOIL_TIMES.replace(PUFFERFISH, FoodSpoilage.getInstance().getConfig().getInt("PUFFERFISH"));
-        SPOIL_TIMES.replace(MUSHROOM_STEW, FoodSpoilage.getInstance().getConfig().getInt("MUSHROOM_STEW"));
-        SPOIL_TIMES.replace(RABBIT_STEW, FoodSpoilage.getInstance().getConfig().getInt("RABBIT_STEW"));
-        SPOIL_TIMES.replace(BEETROOT_SOUP, FoodSpoilage.getInstance().getConfig().getInt("BEETROOT_SOUP"));
-        SPOIL_TIMES.replace(COOKED_BEEF, FoodSpoilage.getInstance().getConfig().getInt("COOKED_BEEF"));
-        SPOIL_TIMES.replace(COOKED_PORKCHOP, FoodSpoilage.getInstance().getConfig().getInt("COOKED_PORKCHOP"));
-        SPOIL_TIMES.replace(COOKED_CHICKEN, FoodSpoilage.getInstance().getConfig().getInt("COOKED_CHICKEN"));
-        SPOIL_TIMES.replace(COOKED_SALMON, FoodSpoilage.getInstance().getConfig().getInt("COOKED_SALMON"));
-        SPOIL_TIMES.replace(COOKED_MUTTON, FoodSpoilage.getInstance().getConfig().getInt("COOKED_MUTTON"));
-        SPOIL_TIMES.replace(COOKED_RABBIT, FoodSpoilage.getInstance().getConfig().getInt("COOKED_RABBIT"));
-        SPOIL_TIMES.replace(COOKED_COD, FoodSpoilage.getInstance().getConfig().getInt("COOKED_COD"));
-        SPOIL_TIMES.replace(WHEAT, FoodSpoilage.getInstance().getConfig().getInt("WHEAT"));
-        SPOIL_TIMES.replace(MELON, FoodSpoilage.getInstance().getConfig().getInt("MELON"));
-        SPOIL_TIMES.replace(PUMPKIN, FoodSpoilage.getInstance().getConfig().getInt("PUMPKIN"));
-        SPOIL_TIMES.replace(BROWN_MUSHROOM, FoodSpoilage.getInstance().getConfig().getInt("BROWN_MUSHROOM"));
-        SPOIL_TIMES.replace(RED_MUSHROOM, FoodSpoilage.getInstance().getConfig().getInt("RED_MUSHROOM"));
-        SPOIL_TIMES.replace(NETHER_WART, FoodSpoilage.getInstance().getConfig().getInt("NETHER_WART"));
-        SPOIL_TIMES.replace(MELON_SLICE, FoodSpoilage.getInstance().getConfig().getInt("MELON_SLICE"));
-        SPOIL_TIMES.replace(CAKE, FoodSpoilage.getInstance().getConfig().getInt("CAKE"));
-        SPOIL_TIMES.replace(PUMPKIN_PIE, FoodSpoilage.getInstance().getConfig().getInt("PUMPKIN_PIE"));
-        SPOIL_TIMES.replace(SUGAR, FoodSpoilage.getInstance().getConfig().getInt("SUGAR"));
-        SPOIL_TIMES.replace(EGG, FoodSpoilage.getInstance().getConfig().getInt("EGG"));
-        SPOIL_TIMES.replace(SUGAR_CANE, FoodSpoilage.getInstance().getConfig().getInt("SUGAR_CANE"));
-        SPOIL_TIMES.replace(APPLE, FoodSpoilage.getInstance().getConfig().getInt("APPLE"));
-        SPOIL_TIMES.replace(COOKIE, FoodSpoilage.getInstance().getConfig().getInt("COOKIE"));
-        SPOIL_TIMES.replace(POISONOUS_POTATO, FoodSpoilage.getInstance().getConfig().getInt("POISONOUS_POTATO"));
-        SPOIL_TIMES.replace(CHORUS_FRUIT, FoodSpoilage.getInstance().getConfig().getInt("CHORUS_FRUIT"));
-        SPOIL_TIMES.replace(DRIED_KELP, FoodSpoilage.getInstance().getConfig().getInt("DRIED_KELP"));
-        SPOIL_TIMES.replace(BAKED_POTATO, FoodSpoilage.getInstance().getConfig().getInt("BAKED_POTATO"));
-        SPOIL_TIMES.replace(SWEET_BERRIES, FoodSpoilage.getInstance().getConfig().getInt("SWEET_BERRIES"));
-        SPOIL_TIMES.replace(HAY_BLOCK, FoodSpoilage.getInstance().getConfig().getInt("HAY_BLOCK"));
-
-        expiryDateText = FoodSpoilage.getInstance().getConfig().getString("expiryDateText");
-        valuesLoadedText = FoodSpoilage.getInstance().getConfig().getString("valuesLoadedText");
-        noPermsText = FoodSpoilage.getInstance().getConfig().getString("noPermsText");
-        spoiledFoodName = FoodSpoilage.getInstance().getConfig().getString("spoiledFoodName");
-        spoiledFoodLore = FoodSpoilage.getInstance().getConfig().getString("spoiledFoodLore");
-        timeLeftText = FoodSpoilage.getInstance().getConfig().getString("timeLeftText");
-        lessThanAnHour = FoodSpoilage.getInstance().getConfig().getString("lessThanAnHour");
     }
 }

--- a/src/main/java/spoilagesystem/FoodSpoilage.java
+++ b/src/main/java/spoilagesystem/FoodSpoilage.java
@@ -6,12 +6,11 @@ import org.bukkit.plugin.java.JavaPlugin;
 import spoilagesystem.bStats.Metrics;
 
 import java.io.File;
+import java.io.IOException;
 
 public final class FoodSpoilage extends JavaPlugin {
 
     private static FoodSpoilage instance;
-
-    private String version = "v1.10-beta-2";
 
     public static FoodSpoilage getInstance() {
         return instance;
@@ -25,7 +24,7 @@ public final class FoodSpoilage extends JavaPlugin {
 
         // config creation/loading
         if (!(new File("./plugins/FoodSpoilage/config.yml").exists())) {
-            ConfigManager.getInstance().saveConfigDefaults();
+            ConfigManager.getInstance().create();
         } else {
             reloadConfig();
         }
@@ -33,8 +32,6 @@ public final class FoodSpoilage extends JavaPlugin {
         if (!getVersion().equalsIgnoreCase(getConfig().getString("version"))) {
             ConfigManager.getInstance().handleVersionMismatch();
         }
-
-        ConfigManager.getInstance().loadValuesFromConfig();
 
         EventRegistry.getInstance().registerEvents();
 
@@ -53,6 +50,7 @@ public final class FoodSpoilage extends JavaPlugin {
     }
 
     public String getVersion() {
-        return version;
+        return "v1.10-beta-2";
     }
+
 }

--- a/src/main/java/spoilagesystem/LegacyStorageManager.java
+++ b/src/main/java/spoilagesystem/LegacyStorageManager.java
@@ -1,7 +1,10 @@
 package spoilagesystem;
 
+import org.bukkit.Material;
+
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.util.HashMap;
 import java.util.Scanner;
 
 import static org.bukkit.Material.*;
@@ -20,6 +23,8 @@ public class LegacyStorageManager {
         }
         return instance;
     }
+
+    public final HashMap<Material, Integer> spoilTimes = new HashMap<>();
 
     public void legacyLoadValuesFromConfig() {
 
@@ -42,126 +47,126 @@ public class LegacyStorageManager {
                 // get value from each config line and set it to corresponding field
                 value = getValueFromConfigLine(loadReader.nextLine()); // line 2
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(BREAD, value);
+                    spoilTimes.put(BREAD, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine()); // line 3
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(POTATO, value);
+                    spoilTimes.put(POTATO, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine()); // line 4
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(CARROT, value);
+                    spoilTimes.put(CARROT, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine()); // line 5
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(BEETROOT, value);
+                    spoilTimes.put(BEETROOT, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(BEEF, value);
+                    spoilTimes.put(BEEF, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(PORKCHOP, value);
+                    spoilTimes.put(PORKCHOP, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(CHICKEN, value);
+                    spoilTimes.put(CHICKEN, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(COD, value);
+                    spoilTimes.put(COD, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(SALMON, value);
+                    spoilTimes.put(SALMON, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(MUTTON, value);
+                    spoilTimes.put(MUTTON, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(RABBIT, value);
+                    spoilTimes.put(RABBIT, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(TROPICAL_FISH, value);
+                    spoilTimes.put(TROPICAL_FISH, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(PUFFERFISH, value);
+                    spoilTimes.put(PUFFERFISH, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(MUSHROOM_STEW, value);
+                    spoilTimes.put(MUSHROOM_STEW, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(RABBIT_STEW, value);
+                    spoilTimes.put(RABBIT_STEW, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(BEETROOT_SOUP, value);
+                    spoilTimes.put(BEETROOT_SOUP, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(COOKED_BEEF, value);
+                    spoilTimes.put(COOKED_BEEF, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(COOKED_PORKCHOP, value);
+                    spoilTimes.put(COOKED_PORKCHOP, value);
                 }
 
             }
@@ -169,161 +174,161 @@ public class LegacyStorageManager {
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(COOKED_CHICKEN, value);
+                    spoilTimes.put(COOKED_CHICKEN, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(COOKED_SALMON, value);
+                    spoilTimes.put(COOKED_SALMON, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(COOKED_MUTTON, value);
+                    spoilTimes.put(COOKED_MUTTON, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(COOKED_RABBIT, value);
+                    spoilTimes.put(COOKED_RABBIT, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(COOKED_COD, value);
+                    spoilTimes.put(COOKED_COD, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(WHEAT, value);
+                    spoilTimes.put(WHEAT, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(MELON, value);
+                    spoilTimes.put(MELON, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(PUMPKIN, value);
+                    spoilTimes.put(PUMPKIN, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(BROWN_MUSHROOM, value);
+                    spoilTimes.put(BROWN_MUSHROOM, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(RED_MUSHROOM, value);
+                    spoilTimes.put(RED_MUSHROOM, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(NETHER_WART, value);
+                    spoilTimes.put(NETHER_WART, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(MELON, value);
+                    spoilTimes.put(MELON, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(CAKE, value);
+                    spoilTimes.put(CAKE, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(PUMPKIN, value);
+                    spoilTimes.put(PUMPKIN, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(SUGAR, value);
+                    spoilTimes.put(SUGAR, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(EGG, value);
+                    spoilTimes.put(EGG, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(SUGAR_CANE, value);
+                    spoilTimes.put(SUGAR_CANE, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(APPLE, value);
+                    spoilTimes.put(APPLE, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(COOKIE, value);
+                    spoilTimes.put(COOKIE, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(POISONOUS_POTATO, value);
+                    spoilTimes.put(POISONOUS_POTATO, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(CHORUS_FRUIT, value);
+                    spoilTimes.put(CHORUS_FRUIT, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(DRIED_KELP, value);
+                    spoilTimes.put(DRIED_KELP, value);
                 }
             }
 
             if (loadReader.hasNextLine()) {
                 value = getValueFromConfigLine(loadReader.nextLine());
                 if (value != -1) {
-                    ConfigManager.getInstance().getSpoilTimes().put(BAKED_POTATO, value);
+                    spoilTimes.put(BAKED_POTATO, value);
                 }
             }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: FoodSpoilage
 version: 1.10-beta-2
-authors: [DanTheTechMan, Undead_Zeratul, Caibinus]
+authors: [DanTheTechMan, Undead_Zeratul, Caibinus, Callum]
 main: spoilagesystem.FoodSpoilage
 api-version: 1.13
 


### PR DESCRIPTION
To fix #174, I have created a stream-lined caching mechanism for spoil-time gathering.
Instead of storing all of the keys each time the project reloads using _**/fs reload**_ the project now obtains the value at runtime and safely caches it for later retrieval, improving overall runtime impact.

To fix #175, a simple clause of saving the updated version was added.