### PR TITLE
Fix DateTimeParseException crash when spoil-time value is malformed or 0

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -32,7 +32,7 @@ All text values support Minecraft color codes using the `&` prefix (e.g., `&f` f
 
 ## Spoil Times
 
-Spoil times are defined under the `spoil-time` key using [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) format (e.g., `PT24H` for 24 hours, `PT48H` for 48 hours).
+Spoil times are defined under the `spoil-time` key using [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) format (e.g., `PT24H` for 24 hours, `PT48H` for 48 hours). A value of `0` means the item never spoils. Any value that is missing or cannot be parsed as an ISO-8601 duration (and is not `0`) also falls back to no spoilage rather than causing an error.
 
 A `default` value is used for any food item not explicitly listed.
 

--- a/src/main/java/spoilagesystem/config/LocalConfigService.java
+++ b/src/main/java/spoilagesystem/config/LocalConfigService.java
@@ -7,6 +7,7 @@ import spoilagesystem.FoodSpoilage;
 import spoilagesystem.config.migration.ConfigMigration;
 
 import java.time.Duration;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Random;
 
@@ -30,17 +31,25 @@ public final class LocalConfigService {
 
     /**
      * Method to obtain the Spoilage Time for the given Material.
-     * 
+     * Parses an ISO-8601 duration string (e.g. "PT24H") from the config.
+     * Falls back to {@link Duration#ZERO} (no spoilage) if the value is missing,
+     * "0", or cannot be parsed as a duration.
+     *
      * @param type to obtain the spoilage time for.
-     * @return int time.
+     * @return the spoilage duration for the given material.
      * @see org.bukkit.configuration.MemorySection#getInt(String)
      */
     public Duration getTime(Material type) {
         String durationString = plugin.getConfig().getString("spoil-time." + type.toString(), plugin.getConfig().getString("spoil-time.default"));
-        if (durationString == null) return Duration.ZERO;
-        Duration time = Duration.parse(durationString); // Get the time from the config.
-        plugin.getLogger().fine("Time from configuration for " + type.name() + ":\t" + time);
-        return time; // Return the key.
+        if (durationString == null || durationString.trim().equals("0")) return Duration.ZERO;
+        try {
+            Duration time = Duration.parse(durationString); // Get the time from the config.
+            plugin.getLogger().fine("Time from configuration for " + type.name() + ":\t" + time);
+            return time; // Return the key.
+        } catch (DateTimeParseException e) {
+            plugin.getLogger().warning("Invalid spoil-time format for " + type.name() + ": '" + durationString + "'. Expected ISO-8601 duration (e.g. PT24H). Defaulting to no spoilage.");
+            return Duration.ZERO;
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- `LocalConfigService#getTime` called `Duration.parse()` without any error handling, so any `spoil-time.*` config value that isn't a valid ISO-8601 duration string crashed event handling with an uncaught `DateTimeParseException`.
- In particular, the plain value `0` (used by admins to mark an item as never spoiling, e.g. `ROTTEN_FLESH: 0`) is not valid ISO-8601 and always crashed — this is exactly the config and stack trace reported in #233 and #207.
- `getTime` now treats `0` (after trimming) as "never spoils" (`Duration.ZERO`), and catches `DateTimeParseException` for any other malformed value, logging a warning and falling back to `Duration.ZERO` instead of throwing.
- `CONFIG.md` documents the `0` shorthand and the malformed-value fallback behavior.

## Why not PR #234
PR #234 already contains a fix for this same bug, but it was opened against `master` before `master` was rewritten into a single-commit repo-hygiene snapshot (PR #243). Diffing that branch against `develop` (the actual working base per `CONTRIBUTING.md`) pulls in an unrelated revert of features that only exist on `develop` (waxing, furnace-timestamp config), so it can't be merged as-is. This PR reimplements the same fix, scoped cleanly against current `develop`. I'll close #234 with an explanation pointing here.

## Test plan
- [x] `./gradlew clean build` — BUILD SUCCESSFUL
- [x] Traced all three callers of `getTime` (`LocalTimeStampService`, `ItemSpawnListener`, `CraftItemListener`) to confirm they're reachable from routine gameplay events (pickup, spawn, crafting), matching the reported crash-on-every-event behavior in #233/#207.
- [ ] Manual in-game validation against the Docker test server (not run this cycle — no `.env`/server available in this sandbox); recommend validating with a config containing `ROTTEN_FLESH: 0` before release, per `README.md`'s Development section.

Closes #233
Closes #207

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
