### PR TITLE
Fix /fs timeleft reporting "never spoil" when expiry-date-lore is empty

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -11,6 +11,7 @@ The configuration file for Food Spoilage is located at `plugins/FoodSpoilage/con
 | `expiry-date-format` | The date format used for expiry dates displayed in item lore | `MM/dd/yyyy` |
 | `enable-waxing` | Enable the waxing feature, allowing players to craft food with a wax material to make it non-perishable but inedible | `true` |
 | `wax-material` | The [Bukkit Material](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html) name used as the waxing ingredient | `HONEYCOMB` |
+| `timestamp-furnace-output` | Stamp items in the furnace output slot with an expiry date immediately when cooked. This works correctly on older versions of Minecraft, but on 1.20.5+ it causes furnaces to stall after cooking one item, since Minecraft will not continue cooking while custom data is present on the output slot. When left at the default, items are instead stamped lazily the next time they reach a player (inventory close/open, pickup, item spawn, or player join). | `false` |
 
 ## Text Customization
 

--- a/src/main/java/spoilagesystem/timestamp/LocalTimeStampService.java
+++ b/src/main/java/spoilagesystem/timestamp/LocalTimeStampService.java
@@ -195,12 +195,6 @@ public final class LocalTimeStampService {
     public String getTimeLeft(ItemStack item) {
         if (!timeStampAssigned(item)) return null;
 
-        ItemMeta meta = item.getItemMeta();
-        if (meta == null) return null;
-
-        List<String> lore = meta.getLore();
-        if (lore == null || lore.size() < 3) return null;
-
         OffsetDateTime timestamp = getTimeStamp(item);
         if (timestamp == null) return null;
 


### PR DESCRIPTION
## Summary
- A bug was identified in `LocalTimeStampService#getTimeLeft`: the time-remaining lookup was gated on the item's rendered lore having at least 3 lines, a check left over from before the expiry timestamp was moved into the item's `PersistentDataContainer`.
- When `text.expiry-date-lore` is configured as an empty list (or any short lore), `meta.setLore([])` is applied at stamp time, so the item ends up with fewer than 3 lore lines even though its PDC-backed timestamp is set correctly. The stale check caused `getTimeLeft` to return `null`, and `TimeLeftCommand` was observed reporting such items as "This item will never spoil" despite a valid timestamp being present in NBT/PDC data — matching the exact symptom reported in #221.
- The lore-size check has been removed. `getTimeStamp(item)` already resolves the timestamp from PDC (preferred) or a lore-based fallback for legacy pre-PDC items, so the extra check was both redundant and incorrect.
- `CONFIG.md` has been updated to document the `timestamp-furnace-output` config key, which was found to be missing from the docs during this cycle's triage (the option itself was already implemented and merged in PR #237).

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

## Test plan
- [x] `./gradlew clean build` — BUILD SUCCESSFUL
- [x] Source-level trace confirming the fix: with `expiry-date-lore: []`, `assignTimeStamp` sets an empty lore list but still writes the PDC `expiry` key; `timeStampAssigned` returns `true` via the PDC check; the old `getTimeLeft` then returned `null` due to `lore.size() < 3`, while the fixed version proceeds to `getTimeStamp`, which resolves the PDC-stored timestamp correctly.
- [ ] Manual in-game validation against the Docker test server (not run this cycle — no `.env`/server available in this sandbox); recommend validating `/fs timeleft` against a food item with `expiry-date-lore: []` configured before release, per `README.md`'s Development section.

Closes #221

<!-- gardener-tend-dispatch -->
