### PR TITLE
Sync master into develop and correct the synced docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,9 +13,11 @@ making any changes.
 ## Project Structure
 
 - `src/main/java/spoilagesystem/` – Plugin source code
-  - `commands/` – Command executors (e.g. `HelpCommand`, `ReloadCommand`, `TimeleftCommand`)
-  - `config/` – Configuration service (`LocalConfigService`)
+  - `commands/` – Command executors (`DefaultCommand`, `HelpCommand`, `ReloadCommand`, `TimeLeftCommand`)
+  - `config/` – Configuration service (`LocalConfigService`), with `config/migration/` holding config version migrations
+  - `factories/` – Item factories (`SpoiledFoodFactory`)
   - `listeners/` – Bukkit event listeners (crafting, inventory, player interactions)
+  - `rpkit/` – Optional RPKit integration (`FoodSpoilageRpkitExpiryService`)
   - `timestamp/` – Timestamp assignment and lookup service
   - `FoodSpoilage.java` – Main plugin class, registers commands and listeners
 - `src/main/resources/` – `plugin.yml` and `config.yml`
@@ -30,5 +32,5 @@ making any changes.
 ## Contribution Workflow
 
 - Branch from `develop` for all changes.
-- Open a pull request against `develop`, not `main`.
+- Open a pull request against `develop`, not `master`.
 - Reference the related GitHub issue in every pull request description.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,6 @@ making any changes.
 - Language: Java
 - Build tool: Gradle (Groovy DSL)
 - Target platform: Spigot / Paper
-- Test framework: JUnit 5
 
 ## Project Structure
 
@@ -20,15 +19,13 @@ making any changes.
   - `timestamp/` – Timestamp assignment and lookup service
   - `FoodSpoilage.java` – Main plugin class, registers commands and listeners
 - `src/main/resources/` – `plugin.yml` and `config.yml`
-- `src/test/java/` – Unit tests
 
 ## Coding Conventions
 
-- All user-facing strings are sourced from `config.yml` via `LocalConfigService`; never hard-code messages in Java.
+- Prefer sourcing new or updated user-facing strings from `config.yml` via `LocalConfigService`; existing hard-coded messages may be refactored over time.
 - Spoilage and timestamp logic is gated on `Material#isEdible()` — non-edible materials are ignored.
 - Spoil durations are stored as ISO-8601 `java.time.Duration` strings (e.g. `PT24H`) in `config.yml`.
 - Follow the existing package structure when adding new classes.
-- The waxing and salting features can be toggled via `enable-waxing` and `enable-salting` config keys.
 
 ## Contribution Workflow
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,37 @@
+# Copilot Instructions
+
+This repository follows the DPC (Dans Plugins Community) conventions defined at
+https://github.com/Dans-Plugins/dpc-conventions. Read those conventions before
+making any changes.
+
+## Technology Stack
+
+- Language: Java
+- Build tool: Gradle (Groovy DSL)
+- Target platform: Spigot / Paper
+- Test framework: JUnit 5
+
+## Project Structure
+
+- `src/main/java/spoilagesystem/` – Plugin source code
+  - `commands/` – Command executors (e.g. `HelpCommand`, `ReloadCommand`, `TimeleftCommand`)
+  - `config/` – Configuration service (`LocalConfigService`)
+  - `listeners/` – Bukkit event listeners (crafting, inventory, player interactions)
+  - `timestamp/` – Timestamp assignment and lookup service
+  - `FoodSpoilage.java` – Main plugin class, registers commands and listeners
+- `src/main/resources/` – `plugin.yml` and `config.yml`
+- `src/test/java/` – Unit tests
+
+## Coding Conventions
+
+- All user-facing strings are sourced from `config.yml` via `LocalConfigService`; never hard-code messages in Java.
+- Spoilage and timestamp logic is gated on `Material#isEdible()` — non-edible materials are ignored.
+- Spoil durations are stored as ISO-8601 `java.time.Duration` strings (e.g. `PT24H`) in `config.yml`.
+- Follow the existing package structure when adding new classes.
+- The waxing and salting features can be toggled via `enable-waxing` and `enable-salting` config keys.
+
+## Contribution Workflow
+
+- Branch from `develop` for all changes.
+- Open a pull request against `develop`, not `main`.
+- Reference the related GitHub issue in every pull request description.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew clean build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ master, develop ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ master, develop ]
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  release:
+    types: [ created ]
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-attach:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew clean build
+
+      - name: Upload JAR to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: build/libs/*.jar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
+### Added
+
+- Waxing feature: food combined with a wax material (`HONEYCOMB` by default) in a crafting grid becomes non-perishable but inedible, controlled by the `enable-waxing`, `wax-material` and `text.waxed-food-lore` config keys.
+- `timestamp-furnace-output` config option to re-enable stamping of furnace output items on Minecraft versions where it does not stall the furnace.
+- `USER_GUIDE.md` covering prerequisites, first steps, common scenarios and permissions.
+- `COMMANDS.md`, `CONFIG.md` and `CONTRIBUTING.md` documentation, plus a restructured `README.md`.
+- `Build` and `Release` GitHub Actions workflows, and `.github/copilot-instructions.md`.
+
+### Fixed
+
+- `DateTimeParseException` crash when a `spoil-time` value was `0` or otherwise not a valid ISO-8601 duration; such values now fall back to no spoilage.
+- `/fs timeleft` incorrectly reporting that an item will never spoil when `text.expiry-date-lore` was configured as empty.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,16 +43,12 @@ Work items are organized into milestones, which represent a specific version of 
 8. Open a pull request against `develop`, link the related issue with `#<number>`.
 9. Address review feedback.
 
-### Language Files
-
-Update `src/main/resources/lang/` for any user-facing string changes. If you are adding a new language, create a new file there.
-
 ## Testing
 
-Run the unit tests with:
+Run the build to verify your changes compile correctly:
 
-Linux: `./gradlew clean test`  
-Windows: `.\gradlew.bat clean test`
+Linux: `./gradlew clean build`  
+Windows: `.\gradlew.bat clean build`
 
 For manual testing, start a local Spigot server:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,5 @@
-# Contributing Document
+# Contributing
+
 ## Thank You
 Thank you for being interested in contributing to the project! It wouldn't be where it is today without the help of the community. This document will help you get started with contributing to the project.
 
@@ -31,32 +32,32 @@ Work items are tracked as GitHub issues. You can find a full list of issues [her
 Work items are organized into milestones, which represent a specific version of the plugin. You can find the milestones [here](https://github.com/Dans-Plugins/FoodSpoilage/milestones).
 
 ## Making Changes
-- Before you start working on something, make sure there is an issue for it. If there isn't, create one.
-- Create a new branch for your changes using `git checkout -b <branch-name>`. Make sure to name your branch something that is related to the issue you are working on.
-- Make your changes to the code.
-- Test your changes to make sure they work as expected. [More information on testing can be found here](#testing).
-- When you are finished, commit your changes using `git commit -m "Your commit message here"`.
-- Push your changes to your fork using `git push origin <branch-name>`.
-- Open a pull request on the original repository. Make sure to include a description of your changes and link the related issue using #(number).
-- Wait for your pull request to be reviewed. If there are any changes that need to be made, make them and push the changes to your fork. Your pull request will be updated automatically.
-- Once your pull request has been reviewed and approved, it will be merged.
+
+1. Make sure an issue exists for the work. If not, create one.
+2. Switch to `develop`: `git checkout develop`
+3. Create a branch: `git checkout -b <branch-name>`
+4. Make your changes.
+5. Test your changes (see [Testing](#testing)).
+6. Commit: `git commit -m "Description of changes"`
+7. Push: `git push origin <branch-name>`
+8. Open a pull request against `develop`, link the related issue with `#<number>`.
+9. Address review feedback.
+
+### Language Files
+
+Update `src/main/resources/lang/` for any user-facing string changes. If you are adding a new language, create a new file there.
 
 ## Testing
-At this time, there are no unit tests due to a difficulty mocking Spigot. However, you can test your changes by running the plugin on a Spigot server.
 
-### Running a Spigot server with Docker
-If you don't have Docker installed, you can download it [here](https://www.docker.com/products/docker-desktop).
+Run the unit tests with:
 
-To run a Spigot server with Docker, you can use the following command:
+Linux: `./gradlew clean test`  
+Windows: `.\gradlew.bat clean test`
+
+For manual testing, start a local Spigot server:
+
 ```bash
 docker compose up
-```
-
-This will start a Spigot server on your local machine. You can connect to it using the IP `localhost` and the port `25565`.
-
-If you make changes to the code, you can deploy the latest changes by rebuilding the Docker image:
-```bash
-docker compose up --build
 ```
 
 ## Questions

--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ A minecraft plugin to make food go bad.
 ## Usage
 
 ### Documentation
-- [Commands Reference](COMMANDS.md) - Complete list of all commands
-- [Configuration Guide](CONFIG.md) - Detailed config options
+- [User Guide](USER_GUIDE.md) – Getting started and common scenarios
+- [Commands Reference](COMMANDS.md) – Complete list of all commands
+- [Configuration Guide](CONFIG.md) – Detailed configuration options
 
 ### Wiki & Additional Resources
-- [User Guide](https://github.com/Dans-Plugins/FoodSpoilage/wiki/Guide)
+- [Wiki Guide](https://github.com/Dans-Plugins/FoodSpoilage/wiki/Guide)
 - [FAQ](https://github.com/Dans-Plugins/FoodSpoilage/wiki/FAQ)
 
 ## Support
@@ -31,18 +32,22 @@ Please fill out a bug report [here](https://github.com/Dans-Plugins/FoodSpoilage
 - [Notes for Developers](https://github.com/Dans-Plugins/FoodSpoilage/wiki/Developer-Notes)
 
 ## Testing
-To build the plugin, you can use the following command:
+
+### Unit Tests
 
 Linux:
+
 ```bash
-./gradlew clean build
-```
-Windows:
-```cmd
-.\gradlew.bat clean build
+./gradlew clean test
 ```
 
-If you see BUILD SUCCESSFUL, then the build has passed.
+Windows:
+
+```cmd
+.\gradlew.bat clean test
+```
+
+If you see `BUILD SUCCESSFUL`, the tests have passed.
 
 ## Development
 ### Test Server with Plugin Hot-Reloading
@@ -77,7 +82,10 @@ This significantly speeds up the development cycle by eliminating the need for f
 ./down.sh
 ```
 
-## Authors and acknowledgement
+## Authors and Acknowledgement
+
+### Developers
+
 | Name              | Main Contributions                                                       |
 |-------------------|--------------------------------------------------------------------------|
 | Daniel Stephenson | Creator                                                                  |
@@ -85,6 +93,11 @@ This significantly speeds up the development cycle by eliminating the need for f
 | Caibinus          | Fixed some bugs                                                          |
 | Callum            | Fixed some bugs and implemented a caching system for food spoilage times |
 | alyphen           | Migrated the project to gradle, refactored services                      |
+
+### Translators
+
+| Name | Language(s) |
+|------|-------------|
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -33,21 +33,21 @@ Please fill out a bug report [here](https://github.com/Dans-Plugins/FoodSpoilage
 
 ## Testing
 
-### Unit Tests
+### Build
 
 Linux:
 
 ```bash
-./gradlew clean test
+./gradlew clean build
 ```
 
 Windows:
 
 ```cmd
-.\gradlew.bat clean test
+.\gradlew.bat clean build
 ```
 
-If you see `BUILD SUCCESSFUL`, the tests have passed.
+If you see `BUILD SUCCESSFUL`, the build has passed.
 
 ## Development
 ### Test Server with Plugin Hot-Reloading

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1,0 +1,59 @@
+# User Guide
+
+## Prerequisites
+
+- A Spigot or Paper Minecraft server (API version 1.13 or later).
+- The FoodSpoilage plugin jar placed in the `plugins/` folder and the server restarted.
+- *(Optional)* [ProtocolLib](https://www.spigotmc.org/resources/protocollib.1997/) – enables additional item-lore features.
+- *(Optional)* rpk-food-lib-bukkit – provides extended food definitions.
+
+## First Steps
+
+1. Start your server with the plugin installed. FoodSpoilage will generate a default `plugins/FoodSpoilage/config.yml`.
+2. Review the configuration file and adjust spoil times and other settings to suit your server. See [CONFIG.md](CONFIG.md) for a full reference.
+3. Reload the configuration without restarting: `/fs reload`
+4. Give the food item you want to test to yourself and check its remaining time with `/fs timeleft`.
+
+## Common Scenarios
+
+### Checking when a food item will expire
+
+1. Hold a food item in your main hand.
+2. Run `/fs timeleft`.
+3. The plugin will display the remaining time before the item spoils.
+
+### Reloading the configuration
+
+After editing `plugins/FoodSpoilage/config.yml`:
+
+```
+/fs reload
+```
+
+### Preventing a player from being affected by spoilage
+
+Grant the `fs.bypass.spoilage` permission to the player. This prevents spoiled food from being converted to rotten flesh for that player.
+
+### Preventing a player's items from receiving timestamps
+
+Grant the `fs.bypass.timestamp` permission to the player. Items crafted or obtained by that player will not receive a spoilage timestamp.
+
+### Using the waxing feature
+
+If `enable-waxing: true` is set in the configuration, players can wax food items by combining them with the configured wax material in a crafting table. Waxed food will not spoil but also cannot be eaten.
+
+### Using the salting feature
+
+If `enable-salting: true` is set in the configuration, players can salt food items by combining them with the configured salt material in a crafting table. Salted food has its spoil timer extended.
+
+## Permissions
+
+| Permission           | Description                                              | Default |
+|----------------------|----------------------------------------------------------|---------|
+| `fs.default`         | Allows use of the base `/fs` command                     | Everyone |
+| `fs.help`            | Allows use of `/fs help`                                 | Everyone |
+| `fs.timeleft`        | Allows use of `/fs timeleft`                             | Everyone |
+| `fs.reload`          | Allows use of `/fs reload`                               | OP only  |
+| `fs.bypass`          | Parent permission granting both bypass permissions below | OP only  |
+| `fs.bypass.spoilage` | Prevents spoiled food from being converted for this player | OP only |
+| `fs.bypass.timestamp`| Prevents timestamp assignment on items for this player  | OP only  |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -21,6 +21,14 @@
 2. Run `/fs timeleft`.
 3. The plugin will display the remaining time before the item spoils.
 
+### Preserving a food item so it never spoils
+
+1. Confirm that `enable-waxing` is set to `true` in the configuration (it is by default).
+2. Place the food item and a honeycomb (or whichever material `wax-material` is set to) together in any crafting grid.
+3. Take the result. The waxed item will never spoil, but it can no longer be eaten.
+
+See [CONFIG.md](CONFIG.md#waxing) for the full description of this feature.
+
 ### Reloading the configuration
 
 After editing `plugins/FoodSpoilage/config.yml`:

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -4,8 +4,7 @@
 
 - A Spigot or Paper Minecraft server (API version 1.13 or later).
 - The FoodSpoilage plugin jar placed in the `plugins/` folder and the server restarted.
-- *(Optional)* [ProtocolLib](https://www.spigotmc.org/resources/protocollib.1997/) – enables additional item-lore features.
-- *(Optional)* rpk-food-lib-bukkit – provides extended food definitions.
+- *(Optional)* rpk-food-lib-bukkit – provides extended food definitions via RPKit integration.
 
 ## First Steps
 
@@ -30,30 +29,11 @@ After editing `plugins/FoodSpoilage/config.yml`:
 /fs reload
 ```
 
-### Preventing a player from being affected by spoilage
-
-Grant the `fs.bypass.spoilage` permission to the player. This prevents spoiled food from being converted to rotten flesh for that player.
-
-### Preventing a player's items from receiving timestamps
-
-Grant the `fs.bypass.timestamp` permission to the player. Items crafted or obtained by that player will not receive a spoilage timestamp.
-
-### Using the waxing feature
-
-If `enable-waxing: true` is set in the configuration, players can wax food items by combining them with the configured wax material in a crafting table. Waxed food will not spoil but also cannot be eaten.
-
-### Using the salting feature
-
-If `enable-salting: true` is set in the configuration, players can salt food items by combining them with the configured salt material in a crafting table. Salted food has its spoil timer extended.
-
 ## Permissions
 
-| Permission           | Description                                              | Default |
-|----------------------|----------------------------------------------------------|---------|
-| `fs.default`         | Allows use of the base `/fs` command                     | Everyone |
-| `fs.help`            | Allows use of `/fs help`                                 | Everyone |
-| `fs.timeleft`        | Allows use of `/fs timeleft`                             | Everyone |
-| `fs.reload`          | Allows use of `/fs reload`                               | OP only  |
-| `fs.bypass`          | Parent permission granting both bypass permissions below | OP only  |
-| `fs.bypass.spoilage` | Prevents spoiled food from being converted for this player | OP only |
-| `fs.bypass.timestamp`| Prevents timestamp assignment on items for this player  | OP only  |
+| Permission    | Description                              | Default  |
+|---------------|------------------------------------------|----------|
+| `fs.default`  | Allows use of the base `/fs` command     | Everyone |
+| `fs.help`     | Allows use of `/fs help`                 | Everyone |
+| `fs.timeleft` | Allows use of `/fs timeleft`             | Everyone |
+| `fs.reload`   | Allows use of `/fs reload`               | OP only  |

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,13 @@ repositories {
 
 dependencies {
     implementation 'com.github.Preponderous-Software:ponder:1.1'
-    implementation 'org.spigotmc:spigot-api:1.14.1-R0.1-SNAPSHOT'
+    // Provided by the server at runtime, so it is kept off the runtime classpath that
+    // shadowJar resolves. Its transitive net.md-5:bungeecord-chat:1.13-SNAPSHOT is no
+    // longer downloadable from any configured repository, so it is excluded outright;
+    // no source file in this project references the net.md_5.bungee API.
+    compileOnly('org.spigotmc:spigot-api:1.14.1-R0.1-SNAPSHOT') {
+        exclude group: 'net.md-5', module: 'bungeecord-chat'
+    }
     implementation 'org.bstats:bstats-bukkit:3.0.0'
     implementation 'com.rpkit:rpk-core-bukkit:2.3.0:all'
     implementation 'com.rpkit:rpk-food-lib-bukkit:2.3.0:all'


### PR DESCRIPTION
## Summary

`develop` and `master` had diverged: the DPC-conventions alignment merged to `master` in #243 was never carried back to `develop`. As a consequence `develop` was missing the `Build` and `Release` GitHub Actions workflows entirely, meaning no continuous-integration check ran on any pull request opened against `develop` — the branch that `CONTRIBUTING.md` directs all contributions to.

`master` is merged into `develop` here, and the files that arrive with it are corrected against the `develop` source tree (which contains the waxing feature and two bug fixes that `master` does not).

### Brought over from `master`

- `.github/workflows/build.yml` and `.github/workflows/release.yml` — continuous integration and release-asset automation.
- `.github/copilot-instructions.md` — the DPC-conventions pointer and coding conventions.
- `CHANGELOG.md` and `USER_GUIDE.md`.
- Editorial updates to `README.md` and `CONTRIBUTING.md`.

The merge was resolved automatically with no conflicts; no file under `src/` is touched by this pull request.

### Corrections applied on top

- `.github/copilot-instructions.md` — the Project Structure section omitted the `factories/` and `rpkit/` packages and the `config/migration/` subpackage, and named a `TimeleftCommand` class that does not exist (the class is `TimeLeftCommand`). The contribution workflow also told contributors to avoid `main`, a branch this repository does not have; `master` is named instead.
- `CHANGELOG.md` — the `[Unreleased]` section was empty. It is populated with the work landed on `develop` since the `3.0.2` tag: the waxing feature, the `timestamp-furnace-output` option, the documentation set, the workflows, and the two bug fixes from #244 and #245.
- `USER_GUIDE.md` — a "Preserving a food item so it never spoils" scenario was added, since waxing is a user-facing feature that exists on `develop` but was undocumented in the guide that arrived from `master`.

### Build fix required to make the incoming workflow pass

Once the `Build` workflow reached `develop` for the first time, it failed immediately on a clean checkout: `spigot-api`'s transitive `net.md-5:bungeecord-chat:1.13-SNAPSHOT` is no longer downloadable from any configured repository, so `shadowJar` could not resolve `runtimeClasspath`. The failure had been invisible locally, because a warm Gradle cache still held the artifact.

`build.gradle` is therefore changed so that `spigot-api` is declared `compileOnly` — correct for a Bukkit plugin, since the server provides the API at runtime — with `net.md-5:bungeecord-chat` excluded outright. No source file references the `net.md_5.bungee` API, so nothing is lost at compile time.

This fix is included rather than deferred because the purpose of this pull request is to give `develop` a working continuous-integration check; landing a workflow that is red on every future pull request would be worse than landing none.

## Test plan

- [x] `./gradlew clean build` — BUILD SUCCESSFUL locally.
- [x] The `Build` workflow was observed failing on commit `0b7ec07` (before the `build.gradle` fix) and passing on commit `e6c7a33` (after it), which is direct empirical confirmation of the dependency fix rather than a reasoned one.
- [x] `./gradlew dependencies --configuration compileClasspath` and `--configuration runtimeClasspath` both confirmed free of `bungeecord-chat` after the change.
- [x] A search of `src/` for `md_5`, `md-5`, `BaseComponent` and `bungee` returned no matches, confirming the excluded module is unused.
- [x] `.github/copilot-instructions.md` Project Structure verified against the actual contents of `src/main/java/spoilagesystem/` and the actual class file names.
- [x] `USER_GUIDE.md` permissions table verified line-by-line against the `permissions:` block of `src/main/resources/plugin.yml` (`fs.default`, `fs.help`, `fs.timeleft` default `true`; `fs.reload` default `op`) — already accurate, so left unchanged.
- [x] The new waxing scenario verified against `WaxingCraftListener` and the `enable-waxing` / `wax-material` keys in `src/main/resources/config.yml`.
- [x] `CHANGELOG.md` entries verified against `git log 3.0.2..origin/develop`.
- [ ] In-game validation on the Docker test server — **not performed, and not applicable**: no file under `src/` is modified, so no runtime plugin behavior changes. The shaded jar was nonetheless inspected after the dependency change to confirm the plugin classes and the relocated `spoilagesystem/shadow` bundle are still present.

## Related issues

No tracking issue existed for this divergence — it was found during triage. Two separate defects found along the way have been filed rather than folded in, so that each can be reviewed on its own rather than being buried in a sync:

- #246 — `build.yml` triggers on `main`, but the default branch is `master`, so nothing on `master` is ever built. Left out because it changes which branches CI covers, which is a maintainer decision.
- #248 — the shipped jar bundles 348 unrelocated `org/junit` entries plus Hamcrest. Left out because the root cause needs confirming before a remedy is chosen.

## Deferred this cycle

The rest of the open backlog was not picked up, for these reasons:

- #226, #222, #145 — in-flight already, as draft Copilot pull requests #227, #225 and #238 respectively. Adopting a draft that a maintainer is actively directing would collide with that work.
- #213 (update to 1.21.4), #181 (server crashes after too many recipes), #212 (multi-part feature request bundle) — larger than a polish-sized change and better scoped by a maintainer.
- #210, #179, #162 — feature requests requiring design decisions rather than mechanical work.
- #204, #160, #25 — bug reports that need in-game reproduction on a live server before any fix can be justified; no reproduction was available this cycle.

Open pull request #232 was also left untouched: it is maintainer-directed Copilot work whose documentation and workflow content is now largely superseded by what `master` already carries, so its disposition is a maintainer call rather than an autonomous one.

## Merge note

This pull request modifies `.github/workflows/*` and `build.gradle`, both of which are on the do-not-auto-merge list, so it is left open for maintainer review rather than being merged automatically.

<!-- gardener-tend-dispatch -->

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).