### PR TITLE
Pin bungeecord-chat to a version that still resolves

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,12 @@ repositories {
     maven { url = uri('https://repo.rpkit.com/repository/maven-releases/') }
 }
 
+configurations.all {
+    // spigot-api 1.14.1 pulls in net.md-5:bungeecord-chat:1.13-SNAPSHOT, which Spigot's snapshot
+    // repository no longer hosts. Pin to the oldest release still published to Maven Central.
+    resolutionStrategy.force 'net.md-5:bungeecord-chat:1.16-R0.1'
+}
+
 dependencies {
     implementation 'com.github.Preponderous-Software:ponder:1.1'
     implementation 'org.spigotmc:spigot-api:1.14.1-R0.1-SNAPSHOT'


### PR DESCRIPTION
## Problem

The `Release` workflow for `4.0.0-SNAPSHOT-8-8-2026` failed, so the release was published **with no jar attached**:

```
Could not find net.md-5:bungeecord-chat:1.13-SNAPSHOT.
  Required by:
      project : > org.spigotmc:spigot-api:1.14.1-R0.1-SNAPSHOT
```

`bungeecord-chat` is not declared by this project — it is pulled in transitively by `spigot-api`. Spigot's snapshot repository no longer hosts it; the entire `net/md-5/bungeecord-chat/` path returns 404 there. Nothing in this repository changed to cause it, and any build would now fail the same way.

## Change

A resolution strategy pins the module to `1.16-R0.1`, the oldest release still published to Maven Central:

```gradle
configurations.all {
    resolutionStrategy.force 'net.md-5:bungeecord-chat:1.16-R0.1'
}
```

The shipped jar is unaffected. `spigot-api` and its transitives are provided by the server at runtime, and `bungeecord-chat` is not among the dependencies `shadowJar` bundles.

## Verification

`./gradlew clean build` was run locally on JDK 17 — the same version the workflow uses:

- `BUILD SUCCESSFUL`, producing `FoodSpoilage-4.0.0-SNAPSHOT-8-8-2026.jar`
- `plugin.yml` in the jar carries `version: 4.0.0-SNAPSHOT-8-8-2026`
- `dependencyInsight` confirms `net.md-5:bungeecord-chat:1.13-SNAPSHOT -> 1.16-R0.1 (forced)`

## Note on CI coverage

No build check will report on this pull request. `build.yml` triggers on branches `[ main, develop ]`, but this repository's default branch is `master` — so pull requests targeting `master`, including release chores, are never built. That gap is why the broken dependency was not caught before the release was cut. Correcting the trigger is left to a separate change, as it is outside the scope of this fix.

Drafted by Claude on behalf of Daniel Stephenson.

🤖 Generated with [Claude Code](https://claude.com/claude-code)