### PR TITLE
Build on master, this repository's default branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ master, develop ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ master, develop ]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

`build.yml` filters on `branches: [ main, develop ]`. This repository has **no `main` branch** — its default branch is `master`. Pushes and pull requests targeting `master` were therefore never built.

Release chores merge to `master`. That is how `4.0.0-SNAPSHOT-8-8-2026` was published with a build that could not resolve `net.md-5:bungeecord-chat`, with no check reporting on the pull request that carried it. The dependency itself was repinned in #250; this closes the gap that let it through.

## Change

```diff
   push:
-    branches: [ main, develop ]
+    branches: [ master, develop ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ master, develop ]
```

`develop` is retained, so existing coverage of feature branches is unchanged. This pull request targets `master` and should be built by the corrected workflow once merged; note that the check will not appear on this pull request itself, since the version being evaluated is still the one on `master`.

## Scope

A fleet-wide scan of all 59 repositories touched by the AI-first version bump found this to be the **only** repository whose workflow branch filters exclude its own default branch. No sibling changes are needed.

Drafted by Claude on behalf of Daniel Stephenson.

🤖 Generated with [Claude Code](https://claude.com/claude-code)