### PR TITLE
Stop shipping JUnit and Hamcrest inside the plugin jar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,4 +18,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `DateTimeParseException` crash when a `spoil-time` value was `0` or otherwise not a valid ISO-8601 duration; such values now fall back to no spoilage.
 - `/fs timeleft` incorrectly reporting that an item will never spoil when `text.expiry-date-lore` was configured as empty.
-- JUnit 4 and Hamcrest classes, carried in from the `ponder` fat jar, were being shipped unrelocated inside the plugin jar and placed on the shared server classpath; they are now excluded, which also reduces the jar from roughly 581 KB to 156 KB.
+- JUnit 4 and Hamcrest classes, carried in from the `ponder` fat jar, were being shipped unrelocated inside the plugin jar and placed on the shared server classpath; they are now excluded along with `ponder`'s own bundled test class, which also reduces the jar from roughly 581 KB to 155 KB.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `DateTimeParseException` crash when a `spoil-time` value was `0` or otherwise not a valid ISO-8601 duration; such values now fall back to no spoilage.
 - `/fs timeleft` incorrectly reporting that an item will never spoil when `text.expiry-date-lore` was configured as empty.
+- JUnit 4 and Hamcrest classes, carried in from the `ponder` fat jar, were being shipped unrelocated inside the plugin jar and placed on the shared server classpath; they are now excluded, which also reduces the jar from roughly 581 KB to 156 KB.

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ shadowJar {
     exclude 'junit/**'
     exclude 'org/hamcrest/**'
     exclude 'LICENSE-junit.txt'
+    // ponder's own test class is the sole consumer of the JUnit classes removed above; shipping it
+    // without them would leave a class whose references cannot be resolved.
+    exclude 'preponderous/ponder/tests/**'
     relocate 'preponderous.ponder', 'spoilagesystem.shadow.preponderous.ponder'
     relocate 'org.intellij', 'spoilagesystem.shadow.org.intellij'
     relocate 'org.jetbrains', 'spoilagesystem.shadow.org.jetbrains'

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,14 @@ shadowJar {
         include(dependency('org.bstats:bstats-bukkit'))
         include(dependency('org.bstats:bstats-base'))
     }
+    // ponder 1.1 is published as a fat jar that carries JUnit 4 and Hamcrest inside it, so the
+    // dependency allow-list above cannot filter them out. Nothing in this plugin touches a test
+    // framework at runtime, and leaving these unrelocated would put org.junit and org.hamcrest on
+    // the shared server classpath alongside every other plugin's.
+    exclude 'org/junit/**'
+    exclude 'junit/**'
+    exclude 'org/hamcrest/**'
+    exclude 'LICENSE-junit.txt'
     relocate 'preponderous.ponder', 'spoilagesystem.shadow.preponderous.ponder'
     relocate 'org.intellij', 'spoilagesystem.shadow.org.intellij'
     relocate 'org.jetbrains', 'spoilagesystem.shadow.org.jetbrains'


### PR DESCRIPTION
## Summary

- `com.github.Preponderous-Software:ponder:1.1` is published as a fat jar: of its 563 entries, 431 are JUnit 4, Hamcrest and `junit/*` classes. Because those classes are physically inside the `ponder` artifact rather than arriving as resolved dependencies, `shadowJar`'s existing `dependencies { include(...) }` allow-list cannot filter them, and they were shipped unrelocated at their original package paths.
- Five `exclude` rules are added to the `shadowJar` block: `org/junit/**`, `junit/**`, `org/hamcrest/**`, `LICENSE-junit.txt`, and `preponderous/ponder/tests/**`. No source file in this project references a test framework at runtime, so nothing is lost.
- The last of those five matters for correctness rather than size. `preponderous.ponder.tests.TestArgumentParser` is the only class in the `ponder` jar that references `org.junit`; removing JUnit without also removing it would have shipped a class whose references cannot be resolved. Every remaining class in the shaded jar was checked for such references and none were found.
- The unrelocated `org.junit` and `org.hamcrest` classes were being placed on the shared Bukkit server classpath alongside every other plugin's, which is where the version-conflict risk described in #248 comes from. That exposure is removed.
- `CHANGELOG.md` records the fix under `[Unreleased]` → `Fixed`.

The alternative remedy — fixing `ponder` upstream so it stops publishing a fat jar — is the more complete one, but it is outside this repository's control and would still leave every already-published `ponder` version affected. The exclusion is therefore applied here.

## Verification

Measured on `build/libs/FoodSpoilage-3.0.2.jar`, built with `./gradlew clean build`:

| | JUnit/Hamcrest entries | Relocated `preponderous.ponder` | Relocated `org.bstats` | Jar size |
|---|---|---|---|---|
| Without the fix (`git stash`) | 431 | 56 | 19 | 581 KB |
| With the fix | **0** | 54 | 19 | **155 KB** |

The stash-and-restore run was performed rather than reasoned about, so the before/after numbers above are observed values. The `ponder` count drops from 56 to 54 because the excluded `preponderous/ponder/tests/` directory entry and its single class are counted there.

## Test plan

- [x] `./gradlew clean build` — BUILD SUCCESSFUL, and the `build` check is green on the pull request head.
- [x] Shaded jar inspected entry by entry: zero `org/junit/`, `junit/` or `org/hamcrest/` entries remain; `spoilagesystem/shadow/preponderous/ponder` (54 entries) and `spoilagesystem/shadow/org/bstats` (19 entries) are intact, as are `plugin.yml`, `config.yml` and every `spoilagesystem/*` class.
- [x] Every `.class` entry in the resulting jar was scanned for residual `org/junit`, `junit/` or `org/hamcrest` constant-pool references; none remain.
- [x] Empirical before/after confirmed by stashing the `build.gradle` change, rebuilding (431 entries), restoring it and rebuilding (0 entries).
- [ ] In-game validation on the Docker test server was **not** performed. This change alters packaging only — no Java source, no `plugin.yml`, no `config.yml` — and the jar was verified to still contain every class it contained before, minus the test scaffolding. A plugin-load check on a live server before the next release would nonetheless be the stronger confirmation, and is recommended.

A note on the anchor: this repository has no automated test suite, and the `Build` workflow verifies compilation only. A green check here does not exercise plugin behaviour in a live server; the jar-composition measurements above are what verify this particular change.

## Deferred this cycle

The remainder of the open backlog was not selected. The reasons are recorded here rather than as comments on each issue:

- #226, #222 and #145 each already have an open draft pull request from another author (#227, #225, #238); duplicating them would not be appropriate work for a packaging cycle.
- #213 (update to 1.21.4), #212 (feature-request grab-bag), #210, #181, #179 and #162 carry feature or version-migration scope well beyond a single-issue polish cycle.
- #204, #160 and #25 are runtime bugs whose verification requires a live server session; they are better paired with a cycle that can perform in-game validation.
- #246 was closed during triage as already resolved, and PR #232 was closed as superseded by the workflows already present on `develop`.
- Branch drift between `develop` and `master` was left out of this pull request to keep the packaging fix reviewable on its own; it is tracked in #253.

Closes #248

<!-- gardener-tend-dispatch -->

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

---

_drafted by Claude on behalf of Daniel Stephenson_