### PR TITLE
ci: retry publishing the dev prerelease before giving up

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -62,16 +62,22 @@ jobs:
           fi
 
           # The dev tag has to move to the new commit. Editing a published release does not move its
-          # tag, so the release and its tag are deleted and recreated. This leaves a window of a few
-          # seconds with no dev release; a client that fetches during it sees "no experimental build
-          # published" and succeeds on the next attempt.
-          gh release delete dev --yes --cleanup-tag || true
+          # tag, so the release and its tag are deleted and recreated. That leaves a window with no
+          # dev release, and a transient API failure inside it would strand the repository there
+          # until someone noticed by hand — which has happened. Each attempt therefore starts from a
+          # clean slate, so a half-finished attempt cannot wedge the next one.
+          published=
+          for attempt in 1 2 3; do
+            if [ -n "${attempt_delay:-}" ]; then sleep "$attempt_delay"; fi
+            attempt_delay=$((attempt * 15))
 
-          gh release create dev \
-            --prerelease \
-            --target "$GITHUB_SHA" \
-            --title "Development build" \
-            --notes "Automated build of \`master\` at ${GITHUB_SHA}.
+            gh release delete dev --yes --cleanup-tag || true
+
+            if gh release create dev \
+              --prerelease \
+              --target "$GITHUB_SHA" \
+              --title "Development build" \
+              --notes "Automated build of \`master\` at ${GITHUB_SHA}.
 
           **This is not a release.** It is unreleased, unreviewed code that has not been through any
           release check, and a broken build can stop a server from starting. Do not run it on a server
@@ -84,4 +90,15 @@ jobs:
           \`\`\`
 
           Return to published releases with \`/dpm get foodspoilage --stable\`." \
-            "${jars[0]}"
+              "${jars[0]}"; then
+              published=1
+              break
+            fi
+
+            echo "Publishing the dev prerelease failed (attempt $attempt of 3)." >&2
+          done
+
+          if [ -z "$published" ]; then
+            echo "Could not publish the dev prerelease after 3 attempts. The dev release may be missing until this workflow is re-run." >&2
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- The `Dev Release` workflow now retries publishing the `dev` prerelease before giving up. The release and its tag have to be deleted and recreated for the tag to move to the new commit, and a transient API failure inside that window previously left the repository with no `dev` release at all until the workflow was re-run by hand. Each attempt now starts from a clean slate, and an exhausted retry fails loudly.
+
 ### Added
 
 - A `Dev Release` workflow, which republishes a rolling `dev` prerelease of `master` on every non-documentation push. This is what Dan's Plugin Manager's experimental channel installs from: `/dpm get foodspoilage --experimental` reads `releases/tags/dev`, so without it there is nothing for that command to download. The prerelease is unreleased, unreviewed code and is marked as such.


### PR DESCRIPTION
Hardening for the `Dev Release` workflow added during the Dan's Plugin Manager experimental-channel rollout.

## The problem this fixes

For DPM to see a new experimental build, the `dev` tag has to move to the new commit — and moving it requires the release to be deleted and recreated, because editing a published release does not move its tag. That leaves a short window in which the repository has no `dev` release.

A transient API failure inside that window strands the repository there. It is not hypothetical: within four days of the rollout, three repositories were affected.

| Repository | Date | Cause | Effect |
|---|---|---|---|
| KDRTracker | 2026-08-13 | GitHub API `HTTP 502` | No `dev` release at all for roughly a day |
| Conquest-Recipes | 2026-08-13 | the same 502 incident | Stale `dev` build |
| SimpleSkills | 2026-08-12 | Maven Central `429` | Stale `dev` build |

Nothing surfaced any of this. It was found by a manual sweep, and for anyone pinned to the experimental channel it would have appeared only as `/dpm update` quietly skipping the plugin.

## The change

Publishing is attempted up to three times, with a growing delay between attempts. Each attempt begins with the delete, so a half-finished previous attempt — release created, asset upload failed — cannot wedge the retry. If all three attempts fail, the run fails with a message saying the `dev` release may be missing until the workflow is re-run.

## Verification

The retry loop was extracted from the workflow and exercised in a shell against a stubbed `gh` that fails a configurable number of times:

- fails 0 times → publishes, exits 0
- fails 2 times → recovers on the third attempt, exits 0 (the KDRTracker scenario)
- fails 3 times → exits 1 with the explicit message

The `--notes` body and the one-JAR assertion are unchanged.

---

_drafted by Claude on behalf of Daniel Stephenson_
