### PR TITLE
Correct CONFIG.md against the actual spoilage implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `DateTimeParseException` crash when a `spoil-time` value was `0` or otherwise not a valid ISO-8601 duration; such values now fall back to no spoilage.
 - `/fs timeleft` incorrectly reporting that an item will never spoil when `text.expiry-date-lore` was configured as empty.
 - JUnit 4 and Hamcrest classes, carried in from the `ponder` fat jar, were being shipped unrelocated inside the plugin jar and placed on the shared server classpath; they are now excluded along with `ponder`'s own bundled test class, which also reduces the jar from roughly 581 KB to 155 KB.
+- `CONFIG.md` described `spoil-chance` as the probability that an item spoils when its timer expires. It is in fact rolled once per unit at craft time, replacing the affected units with `Spoiled Food`; the section has been rewritten to match.
+- `CONFIG.md` claimed that all configuration changes can be applied with `/fs reload`. `debug`, `expiry-date-format` and `wax-material` are read only during startup, and the restriction is now documented.
+- `CONFIG.md` presented all 43 default `spoil-time` entries as active. Eleven of them name materials that Bukkit does not report as edible and are therefore never acted on; they are now marked as such.

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -12,9 +12,9 @@ Three settings are read once while the plugin is starting up, and `/fs reload` r
 | `expiry-date-format` | The date formatter is built during plugin startup and then reused. |
 | `wax-material` | The waxing recipe is registered during plugin startup using the material named at that time. |
 
-Turning `enable-waxing` on or off also has no effect on whether the waxing recipe is registered until the server restarts; see the [Waxing](#waxing) section.
+`enable-waxing` is a partial case. Its value is re-read whenever a player uses a crafting grid, so switching it off does stop the plugin from producing waxed food after a reload — but the recipe itself is registered only at startup, so it is neither removed when the setting is switched off nor added when it is switched on. Change it with the server stopped; see the [Waxing](#waxing) section.
 
-Every other key — including all `text.*` messages, `spoil-time`, `spoil-chance` and `timestamp-furnace-output` — is read fresh each time it is used and does take effect on `/fs reload`.
+Every remaining key — all `text.*` messages, `spoil-time`, `spoil-chance` and `timestamp-furnace-output` — is read fresh each time it is used and does take effect on `/fs reload`.
 
 ## General Options
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,6 +1,20 @@
 # Configuration Guide
 
-The configuration file for Food Spoilage is located at `plugins/FoodSpoilage/config.yml`. Changes to the configuration file can be applied in-game using `/fs reload`.
+The configuration file for Food Spoilage is located at `plugins/FoodSpoilage/config.yml`. Most changes to the configuration file can be applied in-game using `/fs reload`.
+
+## Applying Changes
+
+Three settings are read once while the plugin is starting up, and `/fs reload` reports success without applying them:
+
+| Key | Why a restart is needed |
+|-----|-------------------------|
+| `debug` | The logger's level is set during plugin startup. |
+| `expiry-date-format` | The date formatter is built during plugin startup and then reused. |
+| `wax-material` | The waxing recipe is registered during plugin startup using the material named at that time. |
+
+Turning `enable-waxing` on or off also has no effect on whether the waxing recipe is registered until the server restarts; see the [Waxing](#waxing) section.
+
+Every other key — including all `text.*` messages, `spoil-time`, `spoil-chance` and `timestamp-furnace-output` — is read fresh each time it is used and does take effect on `/fs reload`.
 
 ## General Options
 
@@ -41,6 +55,14 @@ A `default` value is used for any food item not explicitly listed.
 |-----|-------------|---------|
 | `spoil-time.default` | Default spoil time for unlisted food items | `PT24H` (24 hours) |
 
+### Only edible materials can spoil
+
+A `spoil-time` entry takes effect only for materials that Bukkit reports as edible — that is, materials a player can actually eat. Rotten flesh is excluded as well, and waxed items are skipped. An entry for any other material is accepted by the configuration parser but never acted on, because every code path that stamps an item with an expiry date checks edibility first.
+
+Eleven of the entries shipped in the default configuration name materials that are **not** edible, and therefore have no effect: `WHEAT`, `HAY_BLOCK`, `MELON`, `PUMPKIN`, `BROWN_MUSHROOM`, `RED_MUSHROOM`, `NETHER_WART`, `CAKE`, `SUGAR`, `EGG` and `SUGAR_CANE`. They are listed in the table below for completeness, and are marked accordingly. Whether they should be removed from the default configuration or the edibility restriction relaxed is tracked in [#257](https://github.com/Dans-Plugins/FoodSpoilage/issues/257).
+
+The one exception is the optional RPKit integration: when `rpk-food-lib-bukkit` is installed, expiry dates requested through RPKit are applied without the edibility check.
+
 ### Configured Food Items
 
 | Item | Spoil Time | Duration |
@@ -68,19 +90,19 @@ A `default` value is used for any food item not explicitly listed.
 | `COOKED_MUTTON` | `PT72H` | 72 hours |
 | `COOKED_RABBIT` | `PT72H` | 72 hours |
 | `COOKED_COD` | `PT72H` | 72 hours |
-| `WHEAT` | `PT48H` | 48 hours |
-| `HAY_BLOCK` | `PT48H` | 48 hours |
-| `MELON` | `PT48H` | 48 hours |
-| `PUMPKIN` | `PT48H` | 48 hours |
-| `BROWN_MUSHROOM` | `PT48H` | 48 hours |
-| `RED_MUSHROOM` | `PT48H` | 48 hours |
-| `NETHER_WART` | `PT168H` | 168 hours (7 days) |
+| `WHEAT` | `PT48H` | 48 hours (no effect — not edible) |
+| `HAY_BLOCK` | `PT48H` | 48 hours (no effect — not edible) |
+| `MELON` | `PT48H` | 48 hours (no effect — not edible) |
+| `PUMPKIN` | `PT48H` | 48 hours (no effect — not edible) |
+| `BROWN_MUSHROOM` | `PT48H` | 48 hours (no effect — not edible) |
+| `RED_MUSHROOM` | `PT48H` | 48 hours (no effect — not edible) |
+| `NETHER_WART` | `PT168H` | 168 hours (7 days) (no effect — not edible) |
 | `MELON_SLICE` | `PT24H` | 24 hours |
-| `CAKE` | `PT24H` | 24 hours |
+| `CAKE` | `PT24H` | 24 hours (no effect — not edible) |
 | `PUMPKIN_PIE` | `PT24H` | 24 hours |
-| `SUGAR` | `PT72H` | 72 hours |
-| `EGG` | `PT72H` | 72 hours |
-| `SUGAR_CANE` | `PT48H` | 48 hours |
+| `SUGAR` | `PT72H` | 72 hours (no effect — not edible) |
+| `EGG` | `PT72H` | 72 hours (no effect — not edible) |
+| `SUGAR_CANE` | `PT48H` | 48 hours (no effect — not edible) |
 | `APPLE` | `PT48H` | 48 hours |
 | `COOKIE` | `PT94H` | 94 hours |
 | `POISONOUS_POTATO` | `PT24H` | 24 hours |
@@ -90,7 +112,7 @@ A `default` value is used for any food item not explicitly listed.
 | `SWEET_BERRIES` | `PT48H` | 48 hours |
 
 ### Adding Custom Food Items
-You can add spoil times for any Minecraft material by adding entries under `spoil-time`. Use the [Bukkit Material](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html) name as the key.
+You can add spoil times for any edible Minecraft material by adding entries under `spoil-time`. Use the [Bukkit Material](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html) name as the key. Entries for materials that are not edible are accepted but have no effect — see [Only edible materials can spoil](#only-edible-materials-can-spoil).
 
 Example:
 ```yaml
@@ -100,21 +122,27 @@ spoil-time:
 
 ## Spoil Chance
 
-The `spoil-chance` section allows you to define a probability (0.0 to 1.0) that individual items of a given type will spoil when their timer expires. If not specified for a material, the spoil chance is 0 (no random spoilage).
+The `spoil-chance` section defines the probability (0.0 to 1.0) that each unit of a food item is **already spoiled at the moment it is crafted**. It is not a second chance applied when an item's expiry timer runs out — an item whose timer expires always spoils.
+
+When a player crafts a food item that has a non-zero spoil time, the roll is made once per unit produced. Units that fail the roll are replaced with `Spoiled Food` (named and described by `text.spoiled-food-name` and `text.spoiled-food-lore`); the remainder are stamped with an expiry date as usual. Crafting is the only path that consults `spoil-chance`; food obtained by cooking, fishing, mob drops, or picking items up is never randomly spoiled.
+
+If a material has no `spoil-chance` entry, its chance is 0 and none of its crafted output is spoiled. There is no `spoil-chance.default` key.
+
+Because the roll happens on the crafting path, it is subject to the same edibility restriction described above.
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| `spoil-chance.WHEAT` | Chance that wheat will spoil | `0.3` (30%) |
+| `spoil-chance.WHEAT` | Chance that each crafted wheat is spoiled. `WHEAT` is not edible, so this shipped entry currently has no effect (see [#257](https://github.com/Dans-Plugins/FoodSpoilage/issues/257)). | `0.3` (30%) |
 
 ## Waxing
 
 The waxing feature allows players to preserve food items by combining them with a wax material (default: honeycomb) in a crafting grid. Waxed food will never spoil but cannot be eaten, making it ideal for preserving sentimental "lore items".
 
-To wax a food item, place it alongside a honeycomb (or the configured `wax-material`) in any crafting grid. The result will be a waxed version of the food item that:
+To wax a food item, place it alongside a honeycomb (or the configured `wax-material`) in any crafting grid. Rotten flesh cannot be waxed, and neither can an item that has already been waxed. The result will be a waxed version of the food item that:
 - Will never receive an expiry timestamp
 - Cannot be consumed (eating is prevented)
 - Displays the configured `text.waxed-food-lore` on the item
 
 If the food item has not yet been stamped with an expiry date, any existing custom lore (e.g., from lore items) is preserved alongside the waxed lore.
 
-The feature can be disabled by setting `enable-waxing: false` in the config.
+The feature can be disabled by setting `enable-waxing: false` in the config. The waxing recipe is registered while the plugin is starting up, so this setting — and `wax-material` — should be changed with the server stopped rather than through `/fs reload`. Toggling `enable-waxing` at runtime is currently known to misbehave; this is tracked in [#259](https://github.com/Dans-Plugins/FoodSpoilage/issues/259).

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -37,6 +37,8 @@ After editing `plugins/FoodSpoilage/config.yml`:
 /fs reload
 ```
 
+A few settings — `debug`, `expiry-date-format`, `wax-material` and, in part, `enable-waxing` — are read only while the plugin is starting up. `/fs reload` reports success without applying them, so change those with the server stopped. See [Applying Changes](CONFIG.md#applying-changes) for the full list.
+
 ## Permissions
 
 | Permission    | Description                              | Default  |


### PR DESCRIPTION
## Summary

A documentation accuracy sweep was run over `CONFIG.md`, checking each claim against the source it documents. Three of the claims did not hold. This PR is documentation-only — no behaviour was changed.

- **`spoil-chance` was described with the wrong mechanic.** The section said it is the probability that an item spoils "when their timer expires". `LocalConfigService.determineSpoiledAmount` is reached from exactly one call site — `CraftItemListener.java:60` — so the roll is made once per unit **at craft time**, and the units that fail it are replaced with `Spoiled Food`. An item whose timer expires always spoils; there is no second roll. The section has been rewritten, the absence of a `spoil-chance.default` key stated, and the shipped `spoil-chance.WHEAT` row now describes what it actually does.

- **The guide claimed all changes can be applied with `/fs reload`.** `ReloadCommand` calls `plugin.reloadConfig()` and reports success, but `debug` (`FoodSpoilage.java:45`), `expiry-date-format` (`LocalTimeStampService.java:38`, stored in a `final` field) and `wax-material` (`FoodSpoilage.java:95`, used to register the recipe at `onEnable`) are read only during startup. A new **Applying Changes** section names those keys and confirms that everything else does take effect on reload.

- **All 43 default `spoil-time` entries were presented as active.** Every code path that stamps an item gates on `Material.isEdible()` — `CraftItemListener.java:52`, `EntityDeathListener.java:27`, `EntityPickupItemListener.java:21`, `InventoryCloseListener.java:39`, `ItemSpawnListener.java:34`, `PlayerFishListener.java:27`, `PlayerJoinListener.java:24`, and `LocalTimeStampService.isStampable` for the two `stampIfEligible` callers. Eleven of the configured materials are not edible, so their entries never take effect. The restriction is now stated, those eleven rows are marked, the RPKit exception is noted, and the "Adding Custom Food Items" guidance no longer implies any material can be given a spoil time.

The Waxing section additionally gained the rotten-flesh and already-waxed exclusions enforced by `WaxingCraftListener.java:49` and `:55`, and a note that the recipe is registered at startup. `USER_GUIDE.md`, which told operators to reload after editing the config without qualification, now cross-links the new section.

### How the eleven inert entries were identified

`Material.isEdible()` was evaluated for all 43 configured materials against `spigot-api`, rather than assumed. The eleven that return `false` are `WHEAT`, `HAY_BLOCK`, `MELON`, `PUMPKIN`, `BROWN_MUSHROOM`, `RED_MUSHROOM`, `NETHER_WART`, `CAKE`, `SUGAR`, `EGG` and `SUGAR_CANE`. The 43 rows of the table were also diffed key-for-key and value-for-value against `src/main/resources/config.yml`; they match exactly, including ordering.

## Issues filed rather than fixed here

Per the documentation-sweep rule, code was not changed under a docs cycle. Five findings were filed instead:

- #256 — `fs.admin` is accepted by `/fs reload` but declared in neither `plugin.yml` nor the docs. Documenting it was deliberately deferred, since referencing an unregistered node in the docs would create a different inconsistency.
- #257 — the eleven inert `spoil-time` entries and the inert `spoil-chance.WHEAT` default; a maintainer decision is needed between trimming the config and widening the edibility gate.
- #258 — `/fs reload` silently not applying `expiry-date-format` or `wax-material`.
- #259 — disabling `enable-waxing` at runtime leaves the placeholder waxing recipe craftable.
- #261 — a partially-spoiled non-shift-click craft delivers only one of its two result stacks, destroying the other. Found while re-reading `CraftItemListener` during self-review.

No `Closes #N` reference is included: these are gaps found during triage and self-review, and none of the five is resolved by this PR.

## Test plan

- [x] `./gradlew compileJava` — BUILD SUCCESSFUL
- [x] `./gradlew test` — BUILD SUCCESSFUL (`:test NO-SOURCE`; this project has no automated test suite)
- [x] Every `spoil-time` key and value in `CONFIG.md` diffed against `src/main/resources/config.yml` — 43/43 match, same order
- [x] `Material.isEdible()` evaluated against `spigot-api` for all 43 configured materials
- [x] Every remaining claim in `CONFIG.md` re-read against `LocalConfigService`, `LocalTimeStampService`, `ReloadCommand`, `FoodSpoilage`, `CraftItemListener`, `BlockCookListener` and `WaxingCraftListener`
- [x] Anchor links `#waxing` and `#only-edible-materials-can-spoil` resolve within the document

Only markdown files are changed, so the build anchor cannot verify the content of this PR; the claims were verified by reading the source instead, as itemised above.

## Open pull requests at triage

Three pull requests were open when this cycle began — #225, #227 and #238 — all authored by the Copilot agent rather than by this loop, all still in draft, and all reported unmergeable by GitHub (33, 68 and 30 commits behind `develop` respectively). Each is a feature of roughly 350–470 added lines across up to 16 files, which is at or over the size this loop is scoped to take on, and each is tied to an open feature request (#222, #226, #145). They were therefore neither adopted nor closed: closing another author's in-progress feature work is a maintainer call, and rebasing and reviewing any one of them is a cycle of its own.

## Issues deferred this cycle

| Issue | Reason |
|---|---|
| #253 | `develop`/`master` divergence. The issue itself notes the `build.gradle` conflict "is a judgement call for a maintainer"; it also touches `.github/workflows` and `build.gradle`. |
| #145, #222, #226 | Each already has an open (draft) pull request — #238, #225, #227. |
| #213 | Updating to 1.21.4 is a dependency and API-compatibility change, not a polish-sized PR. |
| #210, #162, #179 | Feature requests. #210 in particular depends on the edibility decision in #257. |
| #212 | Umbrella "Feature Requests" issue with no single actionable change. |
| #25, #160, #181, #204 | Bugs that need reproduction on a running server. With no automated test suite, there is no way to demonstrate a regression guard for these from the repository alone. |
| #256, #257, #258, #259, #261 | Filed during this cycle's triage and self-review. Each is a code change, which a documentation sweep does not make. |

Issue #248 was closed during triage: it was already resolved by #254, merged 2026-08-13.

---

_drafted by Claude on behalf of Daniel Stephenson_
