### PR TITLE
Deliver both stacks of a partially spoiled ordinary-click craft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `USER_GUIDE.md` covering prerequisites, first steps, common scenarios and permissions.
 - `COMMANDS.md`, `CONFIG.md` and `CONTRIBUTING.md` documentation, plus a restructured `README.md`.
 - `Build` and `Release` GitHub Actions workflows, and `.github/copilot-instructions.md`.
+- A JUnit 5 and Mockito test source set, covering how `CraftItemListener` delivers craft results.
 
 ### Fixed
 
+- A craft that was only partially spoiled and taken with an ordinary click handed the player just one of the two resulting stacks, silently destroying the other. The unspoiled remainder is now left in the result slot and the spoiled portion is added to the player's inventory, or dropped at their feet when there is no room.
 - `DateTimeParseException` crash when a `spoil-time` value was `0` or otherwise not a valid ISO-8601 duration; such values now fall back to no spoilage.
 - `/fs timeleft` incorrectly reporting that an item will never spoil when `text.expiry-date-lore` was configured as empty.
 - JUnit 4 and Hamcrest classes, carried in from the `ponder` fat jar, were being shipped unrelocated inside the plugin jar and placed on the shared server classpath; they are now excluded along with `ponder`'s own bundled test class, which also reduces the jar from roughly 581 KB to 155 KB.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,8 @@ Run the build to verify your changes compile correctly:
 Linux: `./gradlew clean build`  
 Windows: `.\gradlew.bat clean build`
 
+The automated tests live in `src/test/java` and are executed as part of that build; they can also be run on their own with `./gradlew test`.
+
 For manual testing, start a local Spigot server:
 
 ```bash

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,19 @@ dependencies {
     implementation 'org.bstats:bstats-bukkit:3.0.0'
     implementation 'com.rpkit:rpk-core-bukkit:2.3.0:all'
     implementation 'com.rpkit:rpk-food-lib-bukkit:2.3.0:all'
+
+    // The Spigot API is compileOnly above, so it is repeated here to put it on the test classpath.
+    testImplementation('org.spigotmc:spigot-api:1.14.1-R0.1-SNAPSHOT') {
+        exclude group: 'net.md-5', module: 'bungeecord-chat'
+    }
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
+    // Mockito 5 defaults to the inline mock maker, which the plugin's final service classes need.
+    testImplementation 'org.mockito:mockito-core:5.11.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.11.0'
+}
+
+test {
+    useJUnitPlatform()
 }
 
 group = 'DansPlugins'

--- a/src/main/java/spoilagesystem/listeners/CraftItemListener.java
+++ b/src/main/java/spoilagesystem/listeners/CraftItemListener.java
@@ -1,6 +1,7 @@
 package spoilagesystem.listeners;
 
 import org.bukkit.Material;
+import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.CraftItemEvent;
@@ -59,15 +60,18 @@ public final class CraftItemListener implements Listener {
             int amountCrafted = getAmountCrafted(event);
             int spoilAmt = configService.determineSpoiledAmount(type, amountCrafted);
             List<ItemStack> results = new ArrayList<>();
+            ItemStack spoiledFood = null;
+            ItemStack freshFood = null;
             int amount = amountCrafted;
             if (spoilAmt > 0) {
                 amount = amountCrafted - spoilAmt;
-                ItemStack spoiledFood = spoiledFoodFactory.createSpoiledFood(spoilAmt);
+                spoiledFood = spoiledFoodFactory.createSpoiledFood(spoilAmt);
                 results.add(spoiledFood);
             }
             if (amount > 0) {
                 item.setAmount(amount);
-                results.add(timeStampService.assignTimeStamp(item));
+                freshFood = timeStampService.assignTimeStamp(item);
+                results.add(freshFood);
             }
             if (event.isShiftClick()) {
                 event.setCancelled(true);
@@ -86,15 +90,30 @@ public final class CraftItemListener implements Listener {
                     }
                 }
                 event.getInventory().setMatrix(newMatrixItems);
-                event.getWhoClicked().getInventory().addItem(results.toArray(ItemStack[]::new)).values()
-                        .forEach(droppedItem -> event.getWhoClicked().getWorld().dropItem(
-                                event.getWhoClicked().getLocation(),
-                                droppedItem
-                        ));
+                giveOrDrop(event.getWhoClicked(), results.toArray(ItemStack[]::new));
             } else {
-                results.stream().findAny().ifPresent(event::setCurrentItem);
+                // The result slot holds a single stack, so when the craft is partially spoiled the
+                // fresh portion is left there and the spoiled portion is delivered separately.
+                // Without this the second stack was silently discarded.
+                ItemStack resultSlotItem = freshFood != null ? freshFood : spoiledFood;
+                if (resultSlotItem == null) {
+                    return;
+                }
+                event.setCurrentItem(resultSlotItem);
+                if (freshFood != null && spoiledFood != null) {
+                    giveOrDrop(event.getWhoClicked(), spoiledFood);
+                }
             }
         }
+    }
+
+    /**
+     * Gives the supplied stacks to the crafter, dropping at their feet whatever the inventory
+     * cannot hold. This mirrors how the rest of the plugin handles a full inventory.
+     */
+    private void giveOrDrop(HumanEntity crafter, ItemStack... items) {
+        crafter.getInventory().addItem(items).values()
+                .forEach(overflow -> crafter.getWorld().dropItem(crafter.getLocation(), overflow));
     }
 
     private int getAmountCrafted(CraftItemEvent event) {

--- a/src/test/java/spoilagesystem/listeners/CraftItemListenerTest.java
+++ b/src/test/java/spoilagesystem/listeners/CraftItemListenerTest.java
@@ -1,0 +1,169 @@
+package spoilagesystem.listeners;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.event.inventory.CraftItemEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.inventory.Recipe;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import spoilagesystem.config.LocalConfigService;
+import spoilagesystem.factories.SpoiledFoodFactory;
+import spoilagesystem.timestamp.LocalTimeStampService;
+
+import java.time.Duration;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link CraftItemListener}, covering how the results of a partially spoiled craft are
+ * delivered to the player.
+ */
+public class CraftItemListenerTest {
+
+    private static final Material CRAFTED_TYPE = Material.COOKIE;
+    private static final int AMOUNT_CRAFTED = 8;
+
+    @Mock
+    private LocalConfigService configService;
+
+    @Mock
+    private LocalTimeStampService timeStampService;
+
+    @Mock
+    private SpoiledFoodFactory spoiledFoodFactory;
+
+    @Mock
+    private CraftItemEvent event;
+
+    @Mock
+    private ItemStack craftedItem;
+
+    @Mock
+    private ItemStack recipeResult;
+
+    @Mock
+    private ItemStack spoiledFood;
+
+    @Mock
+    private Recipe recipe;
+
+    @Mock
+    private HumanEntity crafter;
+
+    @Mock
+    private PlayerInventory crafterInventory;
+
+    @Mock
+    private World world;
+
+    @Mock
+    private Location location;
+
+    private CraftItemListener listener;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        // The plugin instance is unused by the craft handling, so it is left out.
+        listener = new CraftItemListener(null, configService, timeStampService, spoiledFoodFactory);
+
+        when(event.getCurrentItem()).thenReturn(craftedItem);
+        when(event.getRecipe()).thenReturn(recipe);
+        when(event.getWhoClicked()).thenReturn(crafter);
+        when(event.isShiftClick()).thenReturn(false);
+        when(craftedItem.getType()).thenReturn(CRAFTED_TYPE);
+        when(recipe.getResult()).thenReturn(recipeResult);
+        when(recipeResult.getAmount()).thenReturn(AMOUNT_CRAFTED);
+        when(recipeResult.getType()).thenReturn(CRAFTED_TYPE);
+        when(crafter.getInventory()).thenReturn(crafterInventory);
+        when(crafter.getWorld()).thenReturn(world);
+        when(crafter.getLocation()).thenReturn(location);
+        // An empty inventory, so the amount crafted is never trimmed for lack of space.
+        when(crafterInventory.getStorageContents()).thenReturn(new ItemStack[36]);
+        when(configService.getTime(CRAFTED_TYPE)).thenReturn(Duration.ofHours(1));
+        when(timeStampService.isWaxed(craftedItem)).thenReturn(false);
+        when(timeStampService.assignTimeStamp(craftedItem)).thenReturn(craftedItem);
+        when(crafterInventory.addItem(any(ItemStack[].class))).thenReturn(new HashMap<>());
+    }
+
+    @Test
+    void partiallySpoiledOrdinaryClickPlacesFreshFoodInResultSlotAndGivesSpoiledFoodToPlayer() {
+        int spoiledAmount = 3;
+        when(configService.determineSpoiledAmount(CRAFTED_TYPE, AMOUNT_CRAFTED)).thenReturn(spoiledAmount);
+        when(spoiledFoodFactory.createSpoiledFood(spoiledAmount)).thenReturn(spoiledFood);
+
+        listener.onCraftItem(event);
+
+        // The unspoiled remainder stays in the result slot.
+        verify(craftedItem).setAmount(AMOUNT_CRAFTED - spoiledAmount);
+        verify(event).setCurrentItem(craftedItem);
+        // The spoiled portion is handed over as well rather than being discarded.
+        assertEquals(spoiledFood, captureAddedItem());
+        verify(world, never()).dropItem(any(Location.class), any(ItemStack.class));
+    }
+
+    @Test
+    void partiallySpoiledOrdinaryClickDropsSpoiledFoodWhenTheInventoryIsFull() {
+        int spoiledAmount = 3;
+        when(configService.determineSpoiledAmount(CRAFTED_TYPE, AMOUNT_CRAFTED)).thenReturn(spoiledAmount);
+        when(spoiledFoodFactory.createSpoiledFood(spoiledAmount)).thenReturn(spoiledFood);
+        HashMap<Integer, ItemStack> leftovers = new HashMap<>();
+        leftovers.put(0, spoiledFood);
+        when(crafterInventory.addItem(any(ItemStack[].class))).thenReturn(leftovers);
+
+        listener.onCraftItem(event);
+
+        verify(event).setCurrentItem(craftedItem);
+        verify(world).dropItem(location, spoiledFood);
+    }
+
+    @Test
+    void fullySpoiledOrdinaryClickPlacesSpoiledFoodInTheResultSlot() {
+        when(configService.determineSpoiledAmount(CRAFTED_TYPE, AMOUNT_CRAFTED)).thenReturn(AMOUNT_CRAFTED);
+        when(spoiledFoodFactory.createSpoiledFood(AMOUNT_CRAFTED)).thenReturn(spoiledFood);
+
+        listener.onCraftItem(event);
+
+        verify(event).setCurrentItem(spoiledFood);
+        verify(crafterInventory, never()).addItem(any(ItemStack[].class));
+        verify(world, never()).dropItem(any(Location.class), any(ItemStack.class));
+    }
+
+    @Test
+    void unspoiledOrdinaryClickPlacesTimeStampedFoodInTheResultSlot() {
+        when(configService.determineSpoiledAmount(CRAFTED_TYPE, AMOUNT_CRAFTED)).thenReturn(0);
+
+        listener.onCraftItem(event);
+
+        verify(spoiledFoodFactory, never()).createSpoiledFood(anyInt());
+        verify(timeStampService).assignTimeStamp(craftedItem);
+        verify(event).setCurrentItem(craftedItem);
+        verify(crafterInventory, never()).addItem(any(ItemStack[].class));
+    }
+
+    /**
+     * Returns the single stack passed to the crafter's inventory, failing the test if more or
+     * fewer than one stack was handed over.
+     */
+    private ItemStack captureAddedItem() {
+        org.mockito.ArgumentCaptor<ItemStack[]> captor = org.mockito.ArgumentCaptor.forClass(ItemStack[].class);
+        verify(crafterInventory, times(1)).addItem(captor.capture());
+        ItemStack[] added = captor.getValue();
+        assertEquals(1, added.length);
+        return added[0];
+    }
+}


### PR DESCRIPTION
## Summary

Closes #261.

`CraftItemListener` builds a list of craft results and, on the non-shift-click path, selected a single element from it with `results.stream().findAny()`. When a `spoil-chance` roll spoiled part of a crafted stack the list held two entries, so exactly one of them reached the player and the other was destroyed. `Stream.findAny` also carries no ordering guarantee, so which stack survived was not defined by the API; in practice the spoiled portion was kept, since it is added to the list first.

## Changes

- The unspoiled remainder is placed in the result slot and the spoiled portion is delivered separately, so both stacks reach the player. When the whole craft spoils, the spoiled stack is placed in the result slot as before.
- The give-or-drop handling — `addItem(...)` with the returned overflow dropped at the crafter's feet — is extracted into a `giveOrDrop` helper and shared with the shift-click branch. This is the pattern the plugin already uses for a full inventory, in both the shift-click branch here and in `WaxingCraftListener`.
- The reliance on unspecified stream ordering is removed; the stack that goes into the result slot is now chosen explicitly.

## Tests

The repository had no test source set, so `./gradlew test` reported `:test NO-SOURCE` and still printed `BUILD SUCCESSFUL`. A JUnit 5 and Mockito test source set has been added under `src/test/java`, wired up with `useJUnitPlatform()`; the Spigot API is repeated as a `testImplementation` dependency because it is `compileOnly` for the main source set, and Mockito 5 is used because its inline mock maker is required to mock the plugin's `final` service classes. The `Build` workflow runs `./gradlew clean build`, which executes these tests, so they are covered by CI without a workflow change.

Four tests cover `CraftItemListener`: partial spoilage with room in the inventory, partial spoilage with a full inventory, full spoilage, and no spoilage.

Evidence that the new coverage is meaningful, from `./gradlew test` with `JAVA_HOME` set to JDK 17:

- With the production change reverted and the tests in place: 4 tests, 2 failures (`partiallySpoiledOrdinaryClickPlacesFreshFoodInResultSlotAndGivesSpoiledFoodToPlayer` and `partiallySpoiledOrdinaryClickDropsSpoiledFoodWhenTheInventoryIsFull`, both failing on the stack that never reached the player).
- With the production change restored: 4 tests, 0 failures. `./gradlew clean build` also passes.

The two cases that do not involve a partially spoiled stack pass either way, as expected.

_drafted by Claude on behalf of Daniel Stephenson_
